### PR TITLE
Update the required Remix version

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "package.json",
     "README.md"
   ],
-  "dependencies": {
+  "peerDependencies": {
     "@remix-run/node": "^0.19.2",
     "@remix-run/react": "^0.19.2",
     "remix": "^0.19.2"


### PR DESCRIPTION
After upgrading remix to version 0.19.x I started getting errors from the versions mismatch (remix-auth has remix version 0.18.x as a dependency).