### PR TITLE
Create AppleStrategy

### DIFF
--- a/docs/strategies/apple.md
+++ b/docs/strategies/apple.md
@@ -14,7 +14,7 @@ Heres a simple JavaScript example on how you can create the secret:
 const jwt = require("jsonwebtoken");
 const fs = require("fs");
 
-const serviceId = "APPLE_ID"; // the Service ID you created
+const serviceId = "SERVICE_ID"; // the Service ID you created
 const teamId = "TEAM_ID"; // your Apple Developer Team ID, look in the top right corner of the Developer Portal
 const keyId = "KEY_ID"; // the KEY ID of your generated private key
 const privateKey = fs.readFileSync("./key.p8");
@@ -34,10 +34,7 @@ console.log(secret);
 
 ## Caveats with the current Stragegy
 
-There are 2 main caveats with this Strategy currently.
-
-1. Apple uses a POST to the specified Callback URL therefore we forward that to a GET Endpoint via a custom Action in Remix.
-2. For now we only support the "email" or none scope.
+There is one main caveats with this Strategy currently. Since Apple only provides scope information (username and email) with the `form_post` respond parameter which is incompatible with the OAuth 2.0 strategy we currently don't support any of the scopes ("email" of "name").
 
 ## Create your session storage
 
@@ -87,7 +84,7 @@ let appleStrategy = new AppleStrategy(
   async (accessToken, refreshToken, extraParams) => {
     let profileData = decode(extraParams.id_token);
     // Get the user data from your DB or API using the tokens and profile
-    return User.findOrCreate({ email: profileData.email });
+    return User.findOrCreate({ sub: profileData.sub });
   }
 );
 
@@ -99,7 +96,7 @@ authenticator.use(appleStrategy);
 ```tsx
 // app/routes/auth.apple.tsx
 import { LoaderFunction } from "remix";
-import { authenticator } from ".~/auth.server";
+import { authenticator } from "~/auth.server";
 
 export let loader: LoaderFunction = async ({ request }) => {
   await authenticator.authenticate("apple", request);
@@ -108,22 +105,11 @@ export let loader: LoaderFunction = async ({ request }) => {
 
 ```tsx
 // app/routes/auth.apple.callback.tsx
-import { LoaderFunction } from "remix";
-import { authenticator } from ".~/auth.server";
+import type { LoaderFunction } from "remix";
+import { authenticator } from "~/utils/auth.server";
 
-export let loader: LoaderFunction = async ({ request }) => {
-  let body = new URLSearchParams(await request.text());
-
-  // construct a URL with the parameters provided in the POST request
-  let url = new URL(request.url);
-  url.search = body.toString();
-
-  // redirect to the callback endpoint
-  return redirect(url.toString());
-};
-
-export let loader: LoaderFunction = async ({ request }) => {
-  await authenticator.authenticate("apple", request, {
+export const loader: LoaderFunction = async ({ request }) => {
+  return authenticator.authenticate("apple", request, {
     failureRedirect: "/error",
     successRedirect: "/dashboard",
   });
@@ -137,18 +123,18 @@ import { json } from "remix-utils";
 import { authenticator } from ".~/auth.server";
 import { User } from ".~/models/user";
 
-type RouteData = { user: User };
+type LoaderData = { user: User };
 
 export let loader: LoaderFunction = async ({ request }) => {
   let user = await authenticator.isAuthenticated(request, {
     redirectTo: "/login",
   });
-  return json<RouteData>({ user });
+  return json<LoaderData>({ user });
 };
 
 // Empty React component required by Remix
 export default function Dashboard() {
-  let { user } = useRouteData<RouteData>();
+  let { user } = useRouteData<LoaderData>();
   // use the user to render the UI of your private route
 }
 ```

--- a/docs/strategies/apple.md
+++ b/docs/strategies/apple.md
@@ -1,0 +1,154 @@
+# AppleStrategy
+
+## Setup your secrets
+
+To be able to use "Sign In with Apple" you need to setup some credentials with Apple. Heres a [Blog Post from Okta](https://developer.okta.com/blog/2019/06/04/what-the-heck-is-sign-in-with-apple#how-sign-in-with-apple-works-hint-it-uses-oauth-and-oidc) which explains in detail how to get the secrets.
+
+### Generating a Client Secret
+
+By default, Apple only provides you with a private key from which you can generate a Client Secret. You can then provide that generated secret to the strategy.
+
+Heres a simple JavaScript example on how you can create the secret:
+
+```js
+const jwt = require("jsonwebtoken");
+const fs = require("fs");
+
+const serviceId = "APPLE_ID"; // the Service ID you created
+const teamId = "TEAM_ID"; // your Apple Developer Team ID, look in the top right corner of the Developer Portal
+const keyId = "KEY_ID"; // the KEY ID of your generated private key
+const privateKey = fs.readFileSync("./key.p8");
+const secret = jwt.sign(
+  {
+    iss: teamId,
+    iat: Math.floor(Date.now() / 1000),
+    exp: Math.floor(Date.now() / 1000) + 86400 * 180, // 6 months
+    aud: "https://appleid.apple.com",
+    sub: serviceId,
+  },
+  privateKey,
+  { algorithm: "ES256", keyid: keyId }
+);
+console.log(secret);
+```
+
+## Caveats with the current Stragegy
+
+There are 2 main caveats with this Strategy currently.
+
+1. Apple uses a POST to the specified Callback URL therefore we forward that to a GET Endpoint via a custom Action in Remix.
+2. For now we only support the "email" or none scope.
+
+## Create your session storage
+
+```ts
+// app/session.server.ts
+import { createCookieSessionStorage } from "remix";
+
+export let sessionStorage = createCookieSessionStorage({
+  cookie: {
+    name: "_session",
+    sameSite: "lax",
+    path: "/",
+    httpOnly: true,
+    secrets: ["s3cr3t"],
+    secure: process.env.NODE_ENV === "production",
+  },
+});
+
+export let { getSession, commitSession, destroySession } = sessionStorage;
+```
+
+## Create an instance of the Authenticator
+
+```ts
+// app/auth.server.ts
+import { Authenticator } from "remix-auth";
+import { sessionStorage } from "~/session.server";
+import { User } from "~/models/user";
+
+// Create an instance of the authenticator, pass a generic with what your
+// strategies will return and will be stored in the session
+export let authenticator = new Authenticator<User>(sessionStorage);
+```
+
+## Create an instance of the AppleStrategy and pass it the authenticator
+
+```ts
+import { AppleStrategy } from "remix-auth";
+import { decode } from "jsonwebtoken";
+
+let appleStrategy = new AppleStrategy(
+  {
+    clientID: "YOUR_CLIENT_ID",
+    clientSecret: "YOUR_CLIENT_SECRET",
+    callbackURL: "/auth/apple/callback",
+  },
+  async (accessToken, refreshToken, extraParams) => {
+    let profileData = decode(extraParams.id_token);
+    // Get the user data from your DB or API using the tokens and profile
+    return User.findOrCreate({ email: profileData.email });
+  }
+);
+
+authenticator.use(appleStrategy);
+```
+
+### Setup your routes
+
+```tsx
+// app/routes/auth.apple.tsx
+import { LoaderFunction } from "remix";
+import { authenticator } from ".~/auth.server";
+
+export let loader: LoaderFunction = async ({ request }) => {
+  await authenticator.authenticate("apple", request);
+};
+```
+
+```tsx
+// app/routes/auth.apple.callback.tsx
+import { LoaderFunction } from "remix";
+import { authenticator } from ".~/auth.server";
+
+export let loader: LoaderFunction = async ({ request }) => {
+  let body = new URLSearchParams(await request.text());
+
+  // construct a URL with the parameters provided in the POST request
+  let url = new URL(request.url);
+  url.search = body.toString();
+
+  // redirect to the callback endpoint
+  return redirect(url.toString());
+};
+
+export let loader: LoaderFunction = async ({ request }) => {
+  await authenticator.authenticate("apple", request, {
+    failureRedirect: "/error",
+    successRedirect: "/dashboard",
+  });
+};
+```
+
+```tsx
+// app/routes/dashboard.tsx
+import { LoaderFunction, redirect } from "remix";
+import { json } from "remix-utils";
+import { authenticator } from ".~/auth.server";
+import { User } from ".~/models/user";
+
+type RouteData = { user: User };
+
+export let loader: LoaderFunction = async ({ request }) => {
+  let user = await authenticator.isAuthenticated(request, {
+    redirectTo: "/login",
+  });
+  return json<RouteData>({ user });
+};
+
+// Empty React component required by Remix
+export default function Dashboard() {
+  let { user } = useRouteData<RouteData>();
+  // use the user to render the UI of your private route
+}
+```

--- a/src/strategies/apple.ts
+++ b/src/strategies/apple.ts
@@ -10,7 +10,6 @@ export interface AppleStrategyOptions {
   clientID: string;
   clientSecret: string;
   callbackURL: string;
-  scope?: "email";
 }
 
 // These interface declare what extra params we will get from Apple on the
@@ -23,14 +22,7 @@ export interface AppleExtraParams extends Record<string, string | number> {
 
 // The AppleProfile extends the OAuth2Profile with the extra params and mark
 // some of them as required
-export interface AppleProfile extends OAuth2Profile {
-  name?: {
-    familyName: string;
-    givenName: string;
-    middleName: string;
-  };
-  email?: string;
-}
+export type AppleProfile = OAuth2Profile;
 
 // And we create our strategy extending the OAuth2Strategy, we also need to
 // pass the User as we did on the FormStrategy, we pass the Auth0Profile and the
@@ -43,7 +35,6 @@ export class AppleStrategy<User> extends OAuth2Strategy<
   // The OAuth2Strategy already has a name but we can override it
   name = "apple";
 
-  private scope: string;
   // We receive our custom options and our verify callback
   constructor(
     options: AppleStrategyOptions,
@@ -63,8 +54,6 @@ export class AppleStrategy<User> extends OAuth2Strategy<
       },
       verify
     );
-
-    this.scope = options.scope || "";
   }
 
   protected async userProfile(): Promise<AppleProfile> {
@@ -77,8 +66,7 @@ export class AppleStrategy<User> extends OAuth2Strategy<
   // you need to send to the authorizationURL here base on your provider.
   protected authorizationParams() {
     return new URLSearchParams({
-      scope: this.scope,
-      response_mode: "form_post",
+      response_mode: "query",
     });
   }
 }

--- a/src/strategies/apple.ts
+++ b/src/strategies/apple.ts
@@ -1,0 +1,84 @@
+// We need to import the OAuth2Strategy, the verify callback and the profile interfaces
+import {
+  OAuth2Profile,
+  OAuth2Strategy,
+  OAuth2StrategyVerifyCallback,
+} from "./oauth2";
+
+// These are the custom options we need from the developer to use the strategy
+export interface AppleStrategyOptions {
+  clientID: string;
+  clientSecret: string;
+  callbackURL: string;
+  scope?: "email";
+}
+
+// These interface declare what extra params we will get from Apple on the
+// verify callback
+export interface AppleExtraParams extends Record<string, string | number> {
+  id_token: string;
+  expires_in: 3600;
+  token_type: "Bearer";
+}
+
+// The AppleProfile extends the OAuth2Profile with the extra params and mark
+// some of them as required
+export interface AppleProfile extends OAuth2Profile {
+  name?: {
+    familyName: string;
+    givenName: string;
+    middleName: string;
+  };
+  email?: string;
+}
+
+// And we create our strategy extending the OAuth2Strategy, we also need to
+// pass the User as we did on the FormStrategy, we pass the Auth0Profile and the
+// extra params
+export class AppleStrategy<User> extends OAuth2Strategy<
+  User,
+  AppleProfile,
+  AppleExtraParams
+> {
+  // The OAuth2Strategy already has a name but we can override it
+  name = "apple";
+
+  private scope: string;
+  // We receive our custom options and our verify callback
+  constructor(
+    options: AppleStrategyOptions,
+    verify: OAuth2StrategyVerifyCallback<User, AppleProfile, AppleExtraParams>
+  ) {
+    // And we pass the options to the super constructor using our own options
+    // to generate them, this was we can ask less configuration to the developer
+    // using our strategy
+
+    super(
+      {
+        authorizationURL: `https://appleid.apple.com/auth/authorize`,
+        tokenURL: `https://appleid.apple.com/auth/token`,
+        clientID: options.clientID,
+        clientSecret: options.clientSecret,
+        callbackURL: options.callbackURL,
+      },
+      verify
+    );
+
+    this.scope = options.scope || "";
+  }
+
+  protected async userProfile(): Promise<AppleProfile> {
+    return { provider: "apple" };
+  }
+
+  // We override the protected authorizationParams method to return a new
+  // URLSearchParams with custom params we want to send to the authorizationURL.
+  // Here we add the scope so Auth0 can use it, you can pass any extra param
+  // you need to send to the authorizationURL here base on your provider.
+  protected authorizationParams() {
+    return new URLSearchParams({
+      scope: this.scope,
+      response_mode: "form_post",
+    });
+  }
+}

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -1,3 +1,4 @@
+export * from "./apple";
 export * from "./auth0";
 export * from "./basic";
 export * from "./custom";

--- a/test/strategies/apple.test.ts
+++ b/test/strategies/apple.test.ts
@@ -1,0 +1,100 @@
+import { createCookieSessionStorage } from "remix";
+import { AppleStrategy } from "../../src";
+
+describe(AppleStrategy, () => {
+  let verify = jest.fn();
+  let sessionStorage = createCookieSessionStorage({
+    cookie: { secrets: ["s3cr3t"] },
+  });
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test("should allow changing the scope", async () => {
+    let strategy = new AppleStrategy(
+      {
+        clientID: "CLIENT_ID",
+        clientSecret: "CLIENT_SECRET",
+        callbackURL: "https://example.app/callback",
+        scope: "email",
+      },
+      verify
+    );
+
+    let request = new Request("https://example.app/auth/apple");
+
+    try {
+      await strategy.authenticate(request, sessionStorage, {
+        sessionKey: "user",
+      });
+    } catch (error) {
+      if (!(error instanceof Response)) throw error;
+      let location = error.headers.get("Location");
+
+      if (!location) throw new Error("No redirect header");
+
+      let redirectUrl = new URL(location);
+
+      expect(redirectUrl.searchParams.get("scope")).toBe("email");
+    }
+  });
+
+  test("should have an empty scope if no scope is specified", async () => {
+    let strategy = new AppleStrategy(
+      {
+        clientID: "CLIENT_ID",
+        clientSecret: "CLIENT_SECRET",
+        callbackURL: "https://example.app/callback",
+      },
+      verify
+    );
+
+    let request = new Request("https://example.app/auth/apple");
+
+    try {
+      await strategy.authenticate(request, sessionStorage, {
+        sessionKey: "user",
+      });
+    } catch (error) {
+      if (!(error instanceof Response)) throw error;
+      let location = error.headers.get("Location");
+
+      if (!location) throw new Error("No redirect header");
+
+      let redirectUrl = new URL(location);
+
+      expect(redirectUrl.searchParams.get("scope")).toBe("");
+    }
+  });
+
+  test("should correctly format the authorization URL", async () => {
+    let strategy = new AppleStrategy(
+      {
+        clientID: "CLIENT_ID",
+        clientSecret: "CLIENT_SECRET",
+        callbackURL: "https://example.app/callback",
+      },
+      verify
+    );
+
+    let request = new Request("https://example.app/auth/apple");
+
+    try {
+      await strategy.authenticate(request, sessionStorage, {
+        sessionKey: "user",
+      });
+    } catch (error) {
+      if (!(error instanceof Response)) throw error;
+
+      let location = error.headers.get("Location");
+
+      if (!location) throw new Error("No redirect header");
+
+      let redirectUrl = new URL(location);
+
+      expect(redirectUrl.hostname).toBe("appleid.apple.com");
+      expect(redirectUrl.pathname).toBe("/auth/authorize");
+    }
+  });
+});

--- a/test/strategies/apple.test.ts
+++ b/test/strategies/apple.test.ts
@@ -1,4 +1,5 @@
-import { createCookieSessionStorage } from "remix";
+import { createCookieSessionStorage } from "@remix-run/server-runtime";
+
 import { AppleStrategy } from "../../src";
 
 describe(AppleStrategy, () => {
@@ -11,13 +12,12 @@ describe(AppleStrategy, () => {
     jest.resetAllMocks();
   });
 
-  test("should allow changing the scope", async () => {
+  test("should have no scope specified", async () => {
     let strategy = new AppleStrategy(
       {
         clientID: "CLIENT_ID",
         clientSecret: "CLIENT_SECRET",
         callbackURL: "https://example.app/callback",
-        scope: "email",
       },
       verify
     );
@@ -36,11 +36,11 @@ describe(AppleStrategy, () => {
 
       let redirectUrl = new URL(location);
 
-      expect(redirectUrl.searchParams.get("scope")).toBe("email");
+      expect(redirectUrl.searchParams.get("scope")).toBe(null);
     }
   });
 
-  test("should have an empty scope if no scope is specified", async () => {
+  test("should have response mode query", async () => {
     let strategy = new AppleStrategy(
       {
         clientID: "CLIENT_ID",
@@ -64,7 +64,7 @@ describe(AppleStrategy, () => {
 
       let redirectUrl = new URL(location);
 
-      expect(redirectUrl.searchParams.get("scope")).toBe("");
+      expect(redirectUrl.searchParams.get("response_mode")).toBe("query");
     }
   });
 


### PR DESCRIPTION
I have been working on "Sign In with Apple" for the last few days and thought why not implement it with `remix-auth`.

At first I thought it should be really easy with the already existing `OAuth2Strategy` but of course Apple does some things different from the "classic" OAuth flow. For now I tried to not touch the existing Strategy and worked around the limitations. 

The main Problem I faced was, that Apple provides the callback information in the form_body of a `POST` request. To solve that I created a redirect which moved the information from the form_body into the QueryParams and then use that with the already existing `OAuth2Strategy`, this also solved some errors for me where a Cookie Session could not be loaded when an Action (POST) was called from Apple. In the Docs Section, I documented how I use it right now inside the `auth.apple.callback.tsx` File.

Another limitation is the User Information. In general, you can only request email and name via the scope parameter, but you get the information only once via the callback. I could not find an easy solution to get the JSON from the callback request and pass it to the profile. We could get it the same way the `scope` and `code` is retrieved, but find a way to somehow not make it particular special to the AppleStrategy to provide some information from the callback call to the profile.

I hope this all makes somewhat of sense. For me the Strategy works great by just using the email from the `id_token` but could be of course improved and made more straight forward. That's why I will leave the PR on Draft for now and would be very interested in what you think about it.

Greetings Lennart 👋

#10 