### PR TITLE
Fix examples not returning a Promise in actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ import { getSession, commitSession } from "~/session.server";
 export let action: ActionFunction = async ({ request }) => {
   // Authenticate the request, after that it will redirect to the defined URLs
   // and set the user in the session if it's a success
-  authenticator.authenticate("local", request, {
+  await authenticator.authenticate("local", request, {
     successRedirect: "/dashboard",
     failureRedirect: "/login",
   });

--- a/docs/strategies/github.md
+++ b/docs/strategies/github.md
@@ -52,7 +52,7 @@ import { authenticator } from "~/auth.server";
 export let loader: LoaderFunction = () => redirect("/login");
 
 export let action: ActionFunction = ({ request }) => {
-  authenticator.authenticate("github", request);
+  return authenticator.authenticate("github", request);
 };
 ```
 
@@ -62,7 +62,7 @@ import { ActionFunction, LoaderFunction } from "remix";
 import { authenticator } from "~/auth.server";
 
 export let loader: LoaderFunction = ({ request }) => {
-  authenticator.authenticate("github", request, {
+  return authenticator.authenticate("github", request, {
     successRedirect: "/dashboard",
     failureRedirect: "/login",
   });

--- a/docs/strategies/google.md
+++ b/docs/strategies/google.md
@@ -52,7 +52,7 @@ import { authenticator } from "~/auth.server";
 export let loader: LoaderFunction = () => redirect("/login");
 
 export let action: ActionFunction = ({ request }) => {
-  authenticator.authenticate("google", request);
+  return authenticator.authenticate("google", request);
 };
 ```
 
@@ -62,7 +62,7 @@ import { ActionFunction, LoaderFunction } from "remix";
 import { authenticator } from "~/auth.server";
 
 export let loader: LoaderFunction = ({ request }) => {
-  authenticator.authenticate("google", request, {
+  return authenticator.authenticate("google", request, {
     successRedirect: "/dashboard",
     failureRedirect: "/login",
   });


### PR DESCRIPTION
Fixes #55. The examples in docs (GoogleStrategy and GithubStrategy) and the LocalStrategy example in the readme had actions/loaders that were not returning a Promise.