### PR TITLE
Create Discord Strategy

### DIFF
--- a/docs/strategies/discord.md
+++ b/docs/strategies/discord.md
@@ -1,0 +1,118 @@
+# DiscordStrategy
+
+The Discord strategy is used to authenticate users against aDiscord account. It extends the OAuth2Strategy.
+
+## Usage
+
+### Create an OAuth application
+
+First go to [the Discord Developer Portal](https://discord.com/developers/applications) to create a new application and get a client ID and secret. The client ID and secret are located in the OAuth2 Tab of your Application. Once you are there you can already add your first redirect url, f.e. `http://localhost:3000/auth/discord/callback`.
+
+You can find the detailed Discord OAuth Documentation [here](https://discord.com/developers/docs/topics/oauth2#oauth2).
+
+### Create your session storage
+
+```ts
+// app/session.server.ts
+import { createCookieSessionStorage } from "remix";
+
+export let sessionStorage = createCookieSessionStorage({
+  cookie: {
+    name: "_session",
+    sameSite: "lax",
+    path: "/",
+    httpOnly: true,
+    secrets: ["s3cr3t"],
+    secure: process.env.NODE_ENV === "production",
+  },
+});
+
+export let { getSession, commitSession, destroySession } = sessionStorage;
+```
+
+### Create the strategy instance
+
+```ts
+// app/auth.server.ts
+import { Authenticator, DiscordStrategy } from "remix-auth";
+
+import { sessionStorage } from "~/session.server";
+import type { User } from "~/models/user.model";
+import { getUserByEmail } from "~/models/user.model";
+
+let auth = new Authenticator<User>(sessionStorage);
+
+let discordStrategy = new DiscordStrategy(
+  {
+    clientID: "YOUR_CLIENT_ID",
+    clientSecret: "YOUR_CLIENT_SECRET",
+    callbackURL: "https://example.com/auth/discord/callback",
+  },
+  async (accessToken, refreshToken, extraParams, profile) => {
+    // Get the user data from your DB or API using the tokens and profile
+    return getUserByEmail(profile.emails[0].value);
+  }
+);
+
+auth.use(discordStrategy);
+```
+
+### Setup your routes
+
+```tsx
+// app/routes/login.tsx
+import { Form } from "remix";
+
+export default function Login() {
+  return (
+    <Form action="/auth/discord" method="post">
+      <button>Login with Discord</button>
+    </Form>
+  );
+}
+```
+
+```tsx
+// app/routes/auth/discord.tsx
+import type { ActionFunction, LoaderFunction } from "remix";
+import { redirect } from "remix";
+
+import { auth } from "~/auth.server";
+
+export let loader: LoaderFunction = () => redirect("/login");
+
+export let action: ActionFunction = ({ request }) => {
+  return auth.authenticate("discord", request);
+};
+```
+
+```tsx
+// app/routes/auth/discord.callback.tsx
+import type { LoaderFunction } from "remix";
+import { auth } from "~/auth.server";
+
+export let loader: LoaderFunction = ({ request }) => {
+  return auth.authenticate("discord", request, {
+    successRedirect: "/dashboard",
+    failureRedirect: "/login",
+  });
+};
+```
+
+```tsx
+// app/routes/dashboard.tsx
+import { LoaderFunction } from "remix";
+import { auth } from "~/auth.server";
+
+export let loader: LoaderFunction = async ({ request }) => {
+  return await auth.isAuthenticated(request, {
+    failureRedirect: "/login",
+  });
+};
+
+export default function DashboardPage() {
+  return <div>Dashboard</div>;
+}
+```
+
+That's it, try going to `/login` and press the Login button to start the authentication flow. Make sure to store all your Secrets properly and setup the correct redirect_url once you go to production.

--- a/src/strategies/discord.ts
+++ b/src/strategies/discord.ts
@@ -1,4 +1,8 @@
-import { OAuth2Strategy, OAuth2StrategyVerifyCallback } from "./oauth2";
+import {
+  OAuth2Profile,
+  OAuth2Strategy,
+  OAuth2StrategyVerifyCallback,
+} from "./oauth2";
 
 export interface DiscordStrategyOptions {
   clientID: string;
@@ -17,73 +21,78 @@ export interface DiscordStrategyOptions {
 /**
  * @
  */
-export interface DiscordProfile {
-  /**
-   * the user's id
-   */
+export interface DiscordProfile extends OAuth2Profile {
   id: string;
-  /**
-   * the user's username, not unique across the platform
-   */
-  username: string;
-  /**
-   * the user's 4-digit discord-tag
-   */
-  discriminator: string;
-  /**
-   * the user's avatar hash
-   * @see https://discord.com/developers/docs/reference#image-formatting
-   */
-  avatar?: string;
-  /**
-   * whether the user belongs to an OAuth2 application
-   */
-  bot?: boolean;
-  /**
-   * whether the user is an Official Discord System user (part of the urgent message system)
-   */
-  system?: boolean;
-  /**
-   * whether the user has two factor enabled on their account
-   */
-  mfa_enabled?: boolean;
-  /**
-   * the user's banner hash
-   * @see https://discord.com/developers/docs/reference#image-formatting
-   */
-  banner?: string;
-  /**
-   * the user's banner color encoded as an integer representation of hexadecimal color code
-   */
-  accent_color?: string;
-  /**
-   * the user's chosen language option
-   */
-  locale?: string;
-  /**
-   * 	whether the email on this account has been verified
-   */
-  verified?: boolean;
-  /**
-   * the user's email
-   */
-  email?: string;
-  /**
-   * the flags on a user's account
-   * @see https://discord.com/developers/docs/resources/user#user-object-user-flags
-   */
-  flags?: number;
-  /**
-   * the type of Nitro subscription on a user's account
-   * @see https://discord.com/developers/docs/resources/user#user-object-premium-types
-   */
-  premium_type?: number;
-  /**
-   * the public flags on a user's account
-   * @see https://discord.com/developers/docs/resources/user#user-object-user-flags
-   */
-  public_flags?: number;
-  provider: "discord";
+  displayName: string;
+  emails?: [{ value: string }];
+  photos?: [{ value: string }];
+  __json: {
+    /**
+     * the user's id
+     */
+    id: string;
+    /**
+     * the user's username, not unique across the platform
+     */
+    username: string;
+    /**
+     * the user's 4-digit discord-tag
+     */
+    discriminator: string;
+    /**
+     * the user's avatar hash
+     * @see https://discord.com/developers/docs/reference#image-formatting
+     */
+    avatar?: string;
+    /**
+     * whether the user belongs to an OAuth2 application
+     */
+    bot?: boolean;
+    /**
+     * whether the user is an Official Discord System user (part of the urgent message system)
+     */
+    system?: boolean;
+    /**
+     * whether the user has two factor enabled on their account
+     */
+    mfa_enabled?: boolean;
+    /**
+     * the user's banner hash
+     * @see https://discord.com/developers/docs/reference#image-formatting
+     */
+    banner?: string;
+    /**
+     * the user's banner color encoded as an integer representation of hexadecimal color code
+     */
+    accent_color?: string;
+    /**
+     * the user's chosen language option
+     */
+    locale?: string;
+    /**
+     * 	whether the email on this account has been verified
+     */
+    verified?: boolean;
+    /**
+     * the user's email
+     */
+    email?: string;
+    /**
+     * the flags on a user's account
+     * @see https://discord.com/developers/docs/resources/user#user-object-user-flags
+     */
+    flags?: number;
+    /**
+     * the type of Nitro subscription on a user's account
+     * @see https://discord.com/developers/docs/resources/user#user-object-premium-types
+     */
+    premium_type?: number;
+    /**
+     * the public flags on a user's account
+     * @see https://discord.com/developers/docs/resources/user#user-object-user-flags
+     */
+    public_flags?: number;
+  };
 }
 
 export interface DiscordExtraParams extends Record<string, string | number> {
@@ -145,7 +154,17 @@ export class DiscordStrategy<User> extends OAuth2Strategy<
         Authorization: `Bearer ${accessToken}`,
       },
     });
-    let profile: DiscordProfile = await response.json();
+    let raw: DiscordProfile["__json"] = await response.json();
+
+    let profile: DiscordProfile = {
+      provider: "discord",
+      id: raw.id,
+      displayName: raw.username,
+      emails: raw.email ? [{ value: raw.email }] : undefined,
+      photos: raw.avatar ? [{ value: raw.avatar }] : undefined,
+      __json: raw,
+    };
+
     return profile;
   }
 }

--- a/src/strategies/discord.ts
+++ b/src/strategies/discord.ts
@@ -1,0 +1,151 @@
+import { OAuth2Strategy, OAuth2StrategyVerifyCallback } from "./oauth2";
+
+export interface DiscordStrategyOptions {
+  clientID: string;
+  clientSecret: string;
+  callbackURL: string;
+  /**
+   * @default "identify email"
+   *
+   * See all the possible scopes:
+   * @see https://discord.com/developers/docs/topics/oauth2#shared-resources-oauth2-scopes
+   */
+  scope?: string;
+  prompt?: "none" | "consent";
+}
+
+/**
+ * @
+ */
+export interface DiscordProfile {
+  /**
+   * the user's id
+   */
+  id: string;
+  /**
+   * the user's username, not unique across the platform
+   */
+  username: string;
+  /**
+   * the user's 4-digit discord-tag
+   */
+  discriminator: string;
+  /**
+   * the user's avatar hash
+   * @see https://discord.com/developers/docs/reference#image-formatting
+   */
+  avatar?: string;
+  /**
+   * whether the user belongs to an OAuth2 application
+   */
+  bot?: boolean;
+  /**
+   * whether the user is an Official Discord System user (part of the urgent message system)
+   */
+  system?: boolean;
+  /**
+   * whether the user has two factor enabled on their account
+   */
+  mfa_enabled?: boolean;
+  /**
+   * the user's banner hash
+   * @see https://discord.com/developers/docs/reference#image-formatting
+   */
+  banner?: string;
+  /**
+   * the user's banner color encoded as an integer representation of hexadecimal color code
+   */
+  accent_color?: string;
+  /**
+   * the user's chosen language option
+   */
+  locale?: string;
+  /**
+   * 	whether the email on this account has been verified
+   */
+  verified?: boolean;
+  /**
+   * the user's email
+   */
+  email?: string;
+  /**
+   * the flags on a user's account
+   * @see https://discord.com/developers/docs/resources/user#user-object-user-flags
+   */
+  flags?: number;
+  /**
+   * the type of Nitro subscription on a user's account
+   * @see https://discord.com/developers/docs/resources/user#user-object-premium-types
+   */
+  premium_type?: number;
+  /**
+   * the public flags on a user's account
+   * @see https://discord.com/developers/docs/resources/user#user-object-user-flags
+   */
+  public_flags?: number;
+  provider: "discord";
+}
+
+export interface DiscordExtraParams extends Record<string, string | number> {
+  expires_in: 604_800;
+  token_type: "Bearer";
+  scope: string;
+}
+
+export class DiscordStrategy<User> extends OAuth2Strategy<
+  User,
+  DiscordProfile,
+  DiscordExtraParams
+> {
+  name = "discord";
+
+  private scope: string;
+  private prompt?: "none" | "consent";
+  private userInfoURL = "https://discord.com/api/users/@me";
+
+  constructor(
+    {
+      clientID,
+      clientSecret,
+      callbackURL,
+      scope,
+      prompt,
+    }: DiscordStrategyOptions,
+    verify: OAuth2StrategyVerifyCallback<
+      User,
+      DiscordProfile,
+      DiscordExtraParams
+    >
+  ) {
+    super(
+      {
+        clientID,
+        clientSecret,
+        callbackURL,
+        authorizationURL: "https://discord.com/api/oauth2/authorize",
+        tokenURL: "https://discord.com/api/oauth2/token",
+      },
+      verify
+    );
+    this.scope = scope ?? "identify email";
+    this.prompt = prompt;
+  }
+
+  protected authorizationParams() {
+    let params = new URLSearchParams({
+      scope: this.scope,
+    });
+    if (this.prompt) params.set("prompt", this.prompt);
+    return params;
+  }
+
+  protected async userProfile(accessToken: string): Promise<DiscordProfile> {
+    let response = await fetch(this.userInfoURL, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+    let profile: DiscordProfile = await response.json();
+    return profile;
+  }
+}

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -1,6 +1,7 @@
 export * from "./auth0";
 export * from "./basic";
 export * from "./custom";
+export * from "./discord";
 export * from "./github";
 export * from "./google";
 export * from "./kcd";

--- a/test/strategies/discord.test.ts
+++ b/test/strategies/discord.test.ts
@@ -1,0 +1,100 @@
+import { createCookieSessionStorage } from "@remix-run/server-runtime";
+import { DiscordStrategy } from "../../src";
+
+describe(DiscordStrategy, () => {
+  let verify = jest.fn();
+  let sessionStorage = createCookieSessionStorage({
+    cookie: { secrets: ["s3cr3t"] },
+  });
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test("should allow changing the scope", async () => {
+    let strategy = new DiscordStrategy(
+      {
+        clientID: "CLIENT_ID",
+        clientSecret: "CLIENT_SECRET",
+        callbackURL: "https://example.app/callback",
+        scope: "custom",
+      },
+      verify
+    );
+
+    let request = new Request("https://example.app/auth/discord");
+
+    try {
+      await strategy.authenticate(request, sessionStorage, {
+        sessionKey: "user",
+      });
+    } catch (error) {
+      if (!(error instanceof Response)) throw error;
+      let location = error.headers.get("Location");
+
+      if (!location) throw new Error("No redirect header");
+
+      let redirectUrl = new URL(location);
+
+      expect(redirectUrl.searchParams.get("scope")).toBe("custom");
+    }
+  });
+
+  test("should have the scope `identify email` as default", async () => {
+    let strategy = new DiscordStrategy(
+      {
+        clientID: "CLIENT_ID",
+        clientSecret: "CLIENT_SECRET",
+        callbackURL: "https://example.app/callback",
+      },
+      verify
+    );
+
+    let request = new Request("https://example.app/auth/discord");
+
+    try {
+      await strategy.authenticate(request, sessionStorage, {
+        sessionKey: "user",
+      });
+    } catch (error) {
+      if (!(error instanceof Response)) throw error;
+      let location = error.headers.get("Location");
+
+      if (!location) throw new Error("No redirect header");
+
+      let redirectUrl = new URL(location);
+
+      expect(redirectUrl.searchParams.get("scope")).toBe("identify email");
+    }
+  });
+
+  test("should correctly format the authorization URL", async () => {
+    let strategy = new DiscordStrategy(
+      {
+        clientID: "CLIENT_ID",
+        clientSecret: "CLIENT_SECRET",
+        callbackURL: "https://example.app/callback",
+      },
+      verify
+    );
+
+    let request = new Request("https://example.app/auth/discord");
+
+    try {
+      await strategy.authenticate(request, sessionStorage, {
+        sessionKey: "user",
+      });
+    } catch (error) {
+      if (!(error instanceof Response)) throw error;
+
+      let location = error.headers.get("Location");
+
+      if (!location) throw new Error("No redirect header");
+
+      let redirectUrl = new URL(location);
+
+      expect(redirectUrl.hostname).toBe("discord.com");
+      expect(redirectUrl.pathname).toBe("/api/oauth2/authorize");
+    }
+  });
+});


### PR DESCRIPTION
Watched a livestream of @alexanderson1993 earlier today where he played with the Discord Login and Remix and thought this would be a great addition to `remix-auth`. 

The Setup was a really straight forward integration using the existing `OAuth2Strategy`