### PR TITLE
Pass errors thrown from local strategy in an object with a message property

### DIFF
--- a/src/strategies/local.ts
+++ b/src/strategies/local.ts
@@ -68,10 +68,10 @@ export class LocalStrategy<User> implements Strategy<User> {
     // password must be present at the same time.
     if (!username || !password) {
       if (!username) {
-        session.flash(`${this.errorKey}:user`, "Missing username.");
+        session.flash(`${this.errorKey}:user`, { message: "Missing username." });
       }
       if (!password) {
-        session.flash(`${this.errorKey}:pass`, "Missing password.");
+        session.flash(`${this.errorKey}:pass`, { message: "Missing password." });
       }
       let cookie = await sessionStorage.commitSession(session);
       throw redirect(this.loginURL, { headers: { "Set-Cookie": cookie } });

--- a/test/strategies/local.test.ts
+++ b/test/strategies/local.test.ts
@@ -75,7 +75,7 @@ describe(LocalStrategy, () => {
 
       expect(error).toHaveStatus(302);
       expect(error).toRedirect("/login");
-      expect(session.get("auth:local:error:user")).toBe("Missing username.");
+      expect(session.get("auth:local:error:user")).toStrictEqual({ message: "Missing username." });
     }
   });
 
@@ -99,7 +99,7 @@ describe(LocalStrategy, () => {
 
       expect(error).toHaveStatus(302);
       expect(error).toRedirect("/login");
-      expect(session.get("auth:local:error:pass")).toBe("Missing password.");
+      expect(session.get("auth:local:error:pass")).toStrictEqual({ message: "Missing password." });
     }
   });
 
@@ -123,8 +123,8 @@ describe(LocalStrategy, () => {
 
       expect(error).toHaveStatus(302);
       expect(error).toRedirect("/login");
-      expect(session.get("auth:local:error:user")).toBe("Missing username.");
-      expect(session.get("auth:local:error:pass")).toBe("Missing password.");
+      expect(session.get("auth:local:error:user")).toStrictEqual({ message: "Missing username." });
+      expect(session.get("auth:local:error:pass")).toStrictEqual({ message: "Missing password." });
     }
   });
 


### PR DESCRIPTION
All errors `session.flash`-ed by `LocalStrategy` are now objects with a message property.

As discussed on the [Remix discord](https://discord.com/channels/770287896669978684/917803274864844851/917839813460246538).