### PR TITLE
Fix KCD example to await `isAuthenticated` to fix crashes due to unhandled promises

### DIFF
--- a/docs/strategies/kcd.md
+++ b/docs/strategies/kcd.md
@@ -97,7 +97,7 @@ import { auth } from "~/services/auth.server";
 import { sessionStorage } from "~/services/session.server";
 
 export let loader: LoaderFunction = async ({ request }) => {
-  auth.isAuthenticated(request, { successRedirect: "/me" });
+  await auth.isAuthenticated(request, { successRedirect: "/me" });
   let session = await sessionStorage.getSession(request.headers.get("Cookie"));
   // This session key `kcd:magiclink` is the default one used by the KCDStrategy
   // you can customize it passing a `sessionMagicLinkKey` when creating an


### PR DESCRIPTION
Inspired by #55 & #60.

Proven at https://github.com/zainfathoni/kelas.rumahberbagi.com/commit/d3adee307340c7ab69db07e8fc73835e6bd80a88