### PR TITLE
add bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -6,7 +6,7 @@ body:
       value: |
         Thank you for reporting an issue :pray:.
 
-        This issue tracker is for reporting bugs found in Remix-Auth (https://github.com/sergiodxa/remix-auth).
+        This issue tracker is for reporting bugs found in Remix Auth (https://github.com/sergiodxa/remix-auth).
         If you have a question about how to achieve something and are struggling, please post a question
         inside of remix-auth's Discussion's tab: https://github.com/sergiodxa/remix-auth/discussions
         

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,85 @@
+name: '🐛 Bug report'
+description: Create a report to help us improve
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for reporting an issue :pray:.
+
+        This issue tracker is for reporting bugs found in Remix-Auth (https://github.com/sergiodxa/remix-auth).
+        If you have a question about how to achieve something and are struggling, please post a question
+        inside of remix-auth's Discussion's tab: https://github.com/sergiodxa/remix-auth/discussions
+        
+        Before submitting a new bug/issue, please check the links below to see if there is a solution or question posted there already:
+         - remix-auth's Issue's tab: https://github.com/sergiodxa/remix-auth/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc
+         - remix-auth's closed issues tab: https://github.com/sergiodxa/remix-auth/issues?q=is%3Aissue+sort%3Aupdated-desc+is%3Aclosed
+         - remix-auth's Discussion's tab: https://github.com/sergiodxa/remix-auth/discussions
+
+        The more information you fill in, the better the community can help you.
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the bug
+      description: Provide a clear and concise description of the challenge you are running into.
+    validations:
+      required: true
+  - type: input
+    id: link
+    attributes:
+      label: Your Example Website or App
+      description: |
+        Which website or app were you using when the bug happened?
+        Note:
+        - Your bug will may get fixed much faster if we can run your code and it doesn't have dependencies other than the remix-auth npm package.
+        - To create a shareable code example you can use Stackblitz (https://stackblitz.com/). Please no localhost URLs.
+        - Please read these tips for providing a minimal example: https://stackoverflow.com/help/mcve.
+      placeholder: |
+        e.g. https://stackblitz.com/edit/...... OR Github Repo
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce the Bug or Issue
+      description: Describe the steps we have to take to reproduce the behavior.
+      placeholder: |
+        1. Go to '...'
+        2. Click on '....'
+        3. Scroll down to '....'
+        4. See error
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: Provide a clear and concise description of what you expected to happen.
+      placeholder: |
+        As a user, I expected ___ behavior but i am seeing ___
+    validations:
+      required: true
+  - type: textarea
+    id: screenshots_or_videos
+    attributes:
+      label: Screenshots or Videos
+      description: |
+        If applicable, add screenshots or a video to help explain your problem.
+        For more information on the supported file image/file types and the file size limits, please refer
+        to the following link: https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/attaching-files
+      placeholder: |
+        You can drag your video or image files inside of this editor ↓
+  - type: textarea
+    id: platform
+    attributes:
+      label: Platform
+      value: |
+        - OS: [e.g. macOS, Windows, Linux]
+        - Browser: [e.g. Chrome, Safari, Firefox]
+        - Version: [e.g. 91.1]
+    validations:
+      required: true
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,7 +13,7 @@ body:
         Before submitting a new bug/issue, please check the links below to see if there is a solution or question posted there already:
          - Remix Auth's Issues tab: https://github.com/sergiodxa/remix-auth/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc
          - Remix Auth's closed issues tab: https://github.com/sergiodxa/remix-auth/issues?q=is%3Aissue+sort%3Aupdated-desc+is%3Aclosed
-         - remix-auth's Discussion's tab: https://github.com/sergiodxa/remix-auth/discussions
+         - Remix Auth's Discussions tab: https://github.com/sergiodxa/remix-auth/discussions
 
         The more information you fill in, the better the community can help you.
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -12,7 +12,7 @@ body:
         
         Before submitting a new bug/issue, please check the links below to see if there is a solution or question posted there already:
          - Remix Auth's Issues tab: https://github.com/sergiodxa/remix-auth/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc
-         - remix-auth's closed issues tab: https://github.com/sergiodxa/remix-auth/issues?q=is%3Aissue+sort%3Aupdated-desc+is%3Aclosed
+         - Remix Auth's closed issues tab: https://github.com/sergiodxa/remix-auth/issues?q=is%3Aissue+sort%3Aupdated-desc+is%3Aclosed
          - remix-auth's Discussion's tab: https://github.com/sergiodxa/remix-auth/discussions
 
         The more information you fill in, the better the community can help you.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -30,7 +30,7 @@ body:
       description: |
         Which website or app were you using when the bug happened?
         Note:
-        - Your bug will may get fixed much faster if we can run your code and it doesn't have dependencies other than the remix-auth npm package.
+        - Your bug will may get fixed much faster if we can run your code and it doesn't have dependencies other than the Remix Auth npm package.
         - To create a shareable code example you can use Stackblitz (https://stackblitz.com/). Please no localhost URLs.
         - Please read these tips for providing a minimal example: https://stackoverflow.com/help/mcve.
       placeholder: |

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -8,7 +8,7 @@ body:
 
         This issue tracker is for reporting bugs found in Remix Auth (https://github.com/sergiodxa/remix-auth).
         If you have a question about how to achieve something and are struggling, please post a question
-        inside of remix-auth's Discussion's tab: https://github.com/sergiodxa/remix-auth/discussions
+        inside of Remix Auth's Discussions tab: https://github.com/sergiodxa/remix-auth/discussions
         
         Before submitting a new bug/issue, please check the links below to see if there is a solution or question posted there already:
          - remix-auth's Issue's tab: https://github.com/sergiodxa/remix-auth/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -11,7 +11,7 @@ body:
         inside of Remix Auth's Discussions tab: https://github.com/sergiodxa/remix-auth/discussions
         
         Before submitting a new bug/issue, please check the links below to see if there is a solution or question posted there already:
-         - remix-auth's Issue's tab: https://github.com/sergiodxa/remix-auth/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc
+         - Remix Auth's Issues tab: https://github.com/sergiodxa/remix-auth/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc
          - remix-auth's closed issues tab: https://github.com/sergiodxa/remix-auth/issues?q=is%3Aissue+sort%3Aupdated-desc+is%3Aclosed
          - remix-auth's Discussion's tab: https://github.com/sergiodxa/remix-auth/discussions
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 🤔 Feature Requests & Questions 
+    url: https://github.com/sergiodxa/remix-auth/discussions
+    about: Please ask and answer questions here.
+  - name: 💬 Remix Discord Channel 
+    url: https://rmx.as/discord
+    about: Please ask and answer questions here.


### PR DESCRIPTION
## What is the change?
Add `bug_report.yml` file to enable Github's form based issue template
- https://youtu.be/qQE1BUkf2-s?t=23


## Motivation
- encourage's bug reporter's to put more care into their bug report before submission
- this may help maintainer's receive more detailed & higher quality bug report's
- adds helpful tips for user's during the process of creating a bug/issue report

## Demo of Change
- https://github.com/cliffordfajardo/TEST-remix-auth-bug-template/issues/new/choose
![CleanShot 2021-12-12 at 17 51 01](https://user-images.githubusercontent.com/6743796/145740351-72a78be6-1746-4970-8a55-b82257b8b757.png)

![CleanShot 2021-12-12 at 17 54 16](https://user-images.githubusercontent.com/6743796/145740641-2e6a1c41-b86e-4387-ae53-3a031bd21d08.png)

