### PR TITLE
Fix email type in DiscordProfile (Discord Strategy)

### DIFF
--- a/src/strategies/discord.ts
+++ b/src/strategies/discord.ts
@@ -76,7 +76,7 @@ export interface DiscordProfile extends OAuth2Profile {
     /**
      * the user's email
      */
-    email?: string;
+    email?: string | null;
     /**
      * the flags on a user's account
      * @see https://discord.com/developers/docs/resources/user#user-object-user-flags


### PR DESCRIPTION
Even if the email scope is included, the email can still be null.
Having an email linked is not a requirement for a Discord account.
The Discord Docs reflect this too _([https://discord.com/developers/docs/resources/user#user-object-user-structure](https://discord.com/developers/docs/resources/user#user-object-user-structure))_.