### PR TITLE
Update Discord Strategy

### DIFF
--- a/src/strategies/discord.ts
+++ b/src/strategies/discord.ts
@@ -4,7 +4,7 @@ import {
   OAuth2StrategyVerifyCallback,
 } from "./oauth2";
 
-type DiscordScope = "activities.read" | "activities.write" | "applications.builds.read" | "applications.builds.upload" |
+export type DiscordScope = "activities.read" | "activities.write" | "applications.builds.read" | "applications.builds.upload" |
   "applications.commands" | "applications.commands.update" | "applications.entitlements" | "applications.store.update" |
   "bot" | "connections" | "email" | "gdm.join" | "guilds" | "guilds.join" | "guilds.members.read" | "identify" |
   "messages.read" | "relationships.read" | "rpc" | "rpc.activities.write" | "rpc.notifications.read" |

--- a/src/strategies/discord.ts
+++ b/src/strategies/discord.ts
@@ -4,6 +4,12 @@ import {
   OAuth2StrategyVerifyCallback,
 } from "./oauth2";
 
+type DiscordScope = "activities.read" | "activities.write" | "applications.builds.read" | "applications.builds.upload" |
+  "applications.commands" | "applications.commands.update" | "applications.entitlements" | "applications.store.update" |
+  "bot" | "connections" | "email" | "gdm.join" | "guilds" | "guilds.join" | "guilds.members.read" | "identify" |
+  "messages.read" | "relationships.read" | "rpc" | "rpc.activities.write" | "rpc.notifications.read" |
+  "rpc.voice.read" | "rpc.voice.write" | "webhook.incoming";
+
 export interface DiscordStrategyOptions {
   clientID: string;
   clientSecret: string;
@@ -14,7 +20,7 @@ export interface DiscordStrategyOptions {
    * See all the possible scopes:
    * @see https://discord.com/developers/docs/topics/oauth2#shared-resources-oauth2-scopes
    */
-  scope?: Array<string>;
+  scope?: Array<DiscordScope>;
   prompt?: "none" | "consent";
 }
 
@@ -95,10 +101,10 @@ export interface DiscordProfile extends OAuth2Profile {
   };
 }
 
-export interface DiscordExtraParams extends Record<string, Array<string> | string | number> {
+export interface DiscordExtraParams extends Record<string, Array<DiscordScope> | string | number> {
   expires_in: 604_800;
   token_type: "Bearer";
-  scope: Array<string>;
+  scope: Array<DiscordScope>;
 }
 
 export class DiscordStrategy<User> extends OAuth2Strategy<
@@ -108,7 +114,7 @@ export class DiscordStrategy<User> extends OAuth2Strategy<
 > {
   name = "discord";
 
-  private scope: Array<string>;
+  private scope: Array<DiscordScope>;
   private prompt?: "none" | "consent";
   private userInfoURL = "https://discord.com/api/users/@me";
 

--- a/src/strategies/discord.ts
+++ b/src/strategies/discord.ts
@@ -4,6 +4,10 @@ import {
   OAuth2StrategyVerifyCallback,
 } from "./oauth2";
 
+
+/**
+ * @see https://discord.com/developers/docs/topics/oauth2#shared-resources-oauth2-scopes
+ */
 export type DiscordScope = "activities.read" | "activities.write" | "applications.builds.read" | "applications.builds.upload" |
   "applications.commands" | "applications.commands.update" | "applications.entitlements" | "applications.store.update" |
   "bot" | "connections" | "email" | "gdm.join" | "guilds" | "guilds.join" | "guilds.members.read" | "identify" |


### PR DESCRIPTION
I have reworked the additional scopes one must add to the Discord Strategy to be an Array of scopes instead of a string which must contain the scopes seperated by a space.
The underlying functions take care of correctly encoding the scopes in the requests, this should improve the DX, because they don't have to worry about the proper scope encoding.
I have also added the DiscordScope type, so Developers can get IntelliSense on the input.