### PR TITLE
Add AppLoadContext as a strategy and authenticate option

### DIFF
--- a/src/authenticator.ts
+++ b/src/authenticator.ts
@@ -107,7 +107,7 @@ export class Authenticator<User = unknown> {
     request: Request,
     options: Pick<
       AuthenticateOptions,
-      "successRedirect" | "failureRedirect" | "throwOnError"
+      "successRedirect" | "failureRedirect" | "throwOnError" | "context"
     > = {}
   ): Promise<User> {
     const strategyObj = this.strategies.get(strategy);

--- a/src/strategy.ts
+++ b/src/strategy.ts
@@ -1,4 +1,9 @@
-import { json, redirect, SessionStorage } from "@remix-run/server-runtime";
+import {
+  AppLoadContext,
+  json,
+  redirect,
+  SessionStorage,
+} from "@remix-run/server-runtime";
 import { AuthorizationError } from "./error";
 
 /**
@@ -30,6 +35,11 @@ export interface AuthenticateOptions {
    * @default true
    */
   throwOnError?: boolean;
+  /**
+   * The context object received by the loader or action.
+   * This can be used by the strategy if needed.
+   */
+  context?: AppLoadContext;
 }
 
 /**


### PR DESCRIPTION
This will let a verify callback receive the context from the loader/action so it can receive any object from there, like a DB connection.

It's up to the strategy to use it or not.