### PR TITLE
Allow for custom options in authenticate

### DIFF
--- a/src/authenticator.ts
+++ b/src/authenticator.ts
@@ -15,7 +15,7 @@ export interface AuthenticatorOptions {
   throwOnError?: AuthenticateOptions["throwOnError"];
 }
 
-export class Authenticator<User = unknown> {
+export class Authenticator<User = unknown, ExtendAuthenticateOptions = {}> {
   /**
    * A map of the configured strategies, the key is the name of the strategy
    * @private
@@ -109,7 +109,7 @@ export class Authenticator<User = unknown> {
   authenticate(
     strategy: string,
     request: Request,
-    options: Pick<
+    options: ExtendAuthenticateOptions & Pick<
       AuthenticateOptions,
       "successRedirect" | "failureRedirect" | "throwOnError" | "context"
     > = {}


### PR DESCRIPTION
Since it's already possible to access these properties by pure javascript, I think it would make sense to support this pattern with TypeScript.

It allows us to create a pattern like the following example.

```typescript
// auth.server.ts
export let authenticator = new Authenticator<Session, {
  role?: string
}>(sessionStorage);


// admin.tsx
export const loader: LoaderFunction = async ({ request }) => {
  const session = await authenticator.authenticate("firebase", request, {
    role: "admin"
    failureRedirect: "/",
  });
  return json<LoaderData>({ email: session?.email || undefined });
};