### PR TITLE
Abstract authentication checker for token refreshing and user data verification 

### DIFF
--- a/src/authenticator.ts
+++ b/src/authenticator.ts
@@ -179,6 +179,13 @@ export class Authenticator<User = unknown> {
 
     let user: User | null = session.get(this.sessionKey) ?? null;
 
+    const strategy = session?.get(this.sessionStrategyKey || "strategy");
+    const strategyObj = this.strategies.get(strategy);
+
+    if (strategyObj && strategyObj.isAuthenticated) {
+      return await strategyObj.isAuthenticated(request, user, options);
+    }
+
     if (user) {
       if (options.successRedirect) throw redirect(options.successRedirect);
       else return user;

--- a/src/authenticator.ts
+++ b/src/authenticator.ts
@@ -183,7 +183,12 @@ export class Authenticator<User = unknown> {
     const strategyObj = this.strategies.get(strategy);
 
     if (strategyObj && strategyObj.isAuthenticated) {
-      return await strategyObj.isAuthenticated(request, user, options);
+      return await strategyObj.isAuthenticated(
+        request,
+        user,
+        this.sessionStorage,
+        options
+      );
     }
 
     if (user) {

--- a/src/strategy.ts
+++ b/src/strategy.ts
@@ -100,6 +100,32 @@ export abstract class Strategy<User, VerifyOptions> {
   ): Promise<User>;
 
   /**
+   * The verify authentication flow of the strategy.
+   *
+   * Call this to check if the user is authenticated. It will return a Promise
+   * with the user object or null, you can use this to check if the user is
+   * logged-in or not without triggering the whole authentication flow.
+   *
+   * This method is used by strategies to check if the user is authenticated. And refreshing the user session.
+   */
+  public async isAuthenticated(
+    request: Request,
+    user: User | null,
+    options:
+      | { successRedirect?: never; failureRedirect?: never }
+      | { successRedirect: string; failureRedirect?: never }
+      | { successRedirect?: never; failureRedirect: string } = {}
+  ): Promise<User | null> {
+    if (user) {
+      if (options.successRedirect) throw redirect(options.successRedirect);
+      else return user;
+    }
+
+    if (options.failureRedirect) throw redirect(options.failureRedirect);
+    else return null;
+  }
+
+  /**
    * Throw an AuthorizationError or a redirect to the failureRedirect.
    * @param message The error message to set in the session.
    * @param session The session object to set the error in.

--- a/src/strategy.ts
+++ b/src/strategy.ts
@@ -111,6 +111,7 @@ export abstract class Strategy<User, VerifyOptions> {
   public async isAuthenticated(
     request: Request,
     user: User | null,
+    sessionStorage: SessionStorage,
     options:
       | { successRedirect?: never; failureRedirect?: never }
       | { successRedirect: string; failureRedirect?: never }

--- a/test/authenticator.test.ts
+++ b/test/authenticator.test.ts
@@ -1,8 +1,5 @@
-import {
-  createCookieSessionStorage,
-  redirect,
-  SessionStorage,
-} from "@remix-run/server-runtime";
+import { redirect, SessionStorage } from "@remix-run/server-runtime";
+import { createCookieSessionStorage } from "@remix-run/node";
 import { AuthenticateOptions, Authenticator, Strategy } from "../src";
 
 class MockStrategy<User> extends Strategy<User, Record<string, never>> {

--- a/test/authorizers.test.ts
+++ b/test/authorizers.test.ts
@@ -1,7 +1,5 @@
-import {
-  createCookieSessionStorage,
-  redirect,
-} from "@remix-run/server-runtime";
+import { redirect } from "@remix-run/server-runtime";
+import { createCookieSessionStorage } from "@remix-run/node";
 import { forbidden, unauthorized } from "remix-utils";
 import { Authenticator, Authorizer } from "../src";
 


### PR DESCRIPTION
There seems to be a missing feature, like when every page calls `isAuthentication`, but it doesn't verify the user is authorized. E.g., if a user gets blocked, they will still have access to the page, but they should destroy their session.

This will provide support for adding
```ts
public async isAuthenticated(
    request: Request,
    user: User | null,
    options:
      | { successRedirect?: never; failureRedirect?: never }
      | { successRedirect: string; failureRedirect?: never }
      | { successRedirect?: never; failureRedirect: string } = {}
  ): Promise<User | null> {
  // Validate the current user data or refresh the token here. 
  // You will need to return a new commit if you wish to refresh the token. 
  // This will also allow for returning Response like, the default isAuthentication

  return super.isAuthenticated(request, user, options)
}
```

**_Another suggestion:_** Should we extend the options for `isAuthenticated` to allow custom properties like `role` to pass through this?

**_Note:_** _This pull request also changes API updates to the tests. The changes update the API from Remix_