### PR TITLE
Improve successRedirect and failureRedirect types

### DIFF
--- a/src/authenticator.ts
+++ b/src/authenticator.ts
@@ -169,7 +169,7 @@ export class Authenticator<User = unknown> {
   async isAuthenticated(
     request: Request, 
     options: { successRedirect: string; failureRedirect: string }
-  ): Promise<User>;
+  ): Promise<null>;
   async isAuthenticated(
     request: Request,
     options:

--- a/src/authenticator.ts
+++ b/src/authenticator.ts
@@ -167,6 +167,10 @@ export class Authenticator<User = unknown> {
     options: { successRedirect?: never; failureRedirect: string }
   ): Promise<User>;
   async isAuthenticated(
+    request: Request, 
+    options: { successRedirect: string; failureRedirect: string }
+  ): Promise<User>;
+  async isAuthenticated(
     request: Request,
     options:
       | { successRedirect?: never; failureRedirect?: never }

--- a/src/authenticator.ts
+++ b/src/authenticator.ts
@@ -175,7 +175,8 @@ export class Authenticator<User = unknown> {
     options:
       | { successRedirect?: never; failureRedirect?: never }
       | { successRedirect: string; failureRedirect?: never }
-      | { successRedirect?: never; failureRedirect: string } = {}
+      | { successRedirect?: never; failureRedirect: string }
+       = {}
   ): Promise<User | null> {
     let session = await this.sessionStorage.getSession(
       request.headers.get("Cookie")

--- a/src/authenticator.ts
+++ b/src/authenticator.ts
@@ -176,7 +176,7 @@ export class Authenticator<User = unknown> {
       | { successRedirect?: never; failureRedirect?: never }
       | { successRedirect: string; failureRedirect?: never }
       | { successRedirect?: never; failureRedirect: string }
-       = {}
+      | { successRedirect: string; failureRedirect: string } = {}
   ): Promise<User | null> {
     let session = await this.sessionStorage.getSession(
       request.headers.get("Cookie")


### PR DESCRIPTION
Adds an overload typing to the isAuthenticated function for if successRedirect and failureRedirect are both defined.

This fixes an issue where calling the function with both redirects specified will fail to compile.