### PR TITLE
Replace `request.clone()` with `new Request(...)`

### DIFF
--- a/src/authenticator.ts
+++ b/src/authenticator.ts
@@ -116,7 +116,7 @@ export class Authenticator<User = unknown> {
   ): Promise<User> {
     const strategyObj = this.strategies.get(strategy);
     if (!strategyObj) throw new Error(`Strategy ${strategy} not found.`);
-    return strategyObj.authenticate(new Response(request.body, request), this.sessionStorage, {
+    return strategyObj.authenticate(new Request(request.url, request), this.sessionStorage, {
       throwOnError: this.throwOnError,
       ...options,
       sessionKey: this.sessionKey,

--- a/src/authenticator.ts
+++ b/src/authenticator.ts
@@ -116,7 +116,7 @@ export class Authenticator<User = unknown> {
   ): Promise<User> {
     const strategyObj = this.strategies.get(strategy);
     if (!strategyObj) throw new Error(`Strategy ${strategy} not found.`);
-    return strategyObj.authenticate(request.clone(), this.sessionStorage, {
+    return strategyObj.authenticate(new Response(request.body, request), this.sessionStorage, {
       throwOnError: this.throwOnError,
       ...options,
       sessionKey: this.sessionKey,


### PR DESCRIPTION
I received this warning while running in Cloudflare Workers:

```
Your worker called response.clone(), but did not read the body of both clones. 
This is wasteful, as it forces the system to buffer the entire response body in memory, rather than streaming it through. 
This may cause your worker to be unexpectedly terminated for going over the memory limit. 
If you only meant to copy the response headers and metadata (e.g. in order to be able to modify them), use `new Response(response.body, response)` instead
```

This is the only `.clone()` I could find in my worker, and updating this removed the warning. My app still appears to be working correctly