### PR TITLE
Remove dependency on remix-utils

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "3.2.1",
       "license": "MIT",
       "dependencies": {
-        "remix-utils": "^2.2.0",
         "uuid": "^8.3.2"
       },
       "devDependencies": {
@@ -1806,6 +1805,7 @@
       "version": "7.14.8",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.8.tgz",
       "integrity": "sha512-twj3L8Og5SaCRCErB4x4ajbvBIVV77CGeFglHpeg5WC5FF8TZzBWXtTJ4MqaD9QszLYTtr+IsaAL2rEUevb+eg==",
+      "dev": true,
       "dependencies": {
         "regenerator-runtime": "^0.13.4"
       },
@@ -2407,6 +2407,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@remix-run/react/-/react-1.1.1.tgz",
       "integrity": "sha512-vz7my0sqjuL3BpgvSb+pUFjebof54okDLm2wHI09NnlbPS1ILrrp61zeNmDyrA11tFcxS/JrgKS/q1Frk030mg==",
+      "dev": true,
       "dependencies": {
         "react-router-dom": "^6.2.1"
       },
@@ -2419,6 +2420,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-1.1.1.tgz",
       "integrity": "sha512-uTTGSjCn2WTXUShruvTuErpbdbGoLu2dZ/zQ0ZHA0MMgP4VDA8xyuBeRcv/By3xqGcu2zSxcEGv7tRPgzU1AtA==",
+      "dev": true,
       "dependencies": {
         "@types/cookie": "^0.4.0",
         "cookie": "^0.4.1",
@@ -2436,6 +2438,7 @@
       "version": "0.7.3",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
       "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+      "dev": true,
       "engines": {
         "node": ">= 8"
       }
@@ -2545,7 +2548,8 @@
     "node_modules/@types/cookie": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
-      "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q=="
+      "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==",
+      "dev": true
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.5",
@@ -3834,6 +3838,7 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
       "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
+      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -5815,6 +5820,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/history/-/history-5.2.0.tgz",
       "integrity": "sha512-uPSF6lAJb3nSePJ43hN3eKj1dTWpN9gMod0ZssbFTIsen+WehTmEadgL+kg78xLJFdRfrrC//SavDzmRVdE+Ig==",
+      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.7.6"
       }
@@ -7420,7 +7426,8 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
     },
     "node_modules/js-yaml": {
       "version": "3.14.1",
@@ -7497,6 +7504,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
       "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
+      "dev": true,
       "bin": {
         "jsesc": "bin/jsesc"
       },
@@ -7651,6 +7659,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -7992,6 +8001,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8530,6 +8540,7 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
       "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -8542,6 +8553,7 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
       "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
+      "dev": true,
       "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
@@ -8556,6 +8568,7 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.2.1.tgz",
       "integrity": "sha512-2fG0udBtxou9lXtK97eJeET2ki5//UWfQSl1rlJ7quwe6jrktK9FCCc8dQb5QY6jAv3jua8bBQRhhDOM/kVRsg==",
+      "dev": true,
       "dependencies": {
         "history": "^5.2.0"
       },
@@ -8567,6 +8580,7 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.2.1.tgz",
       "integrity": "sha512-I6Zax+/TH/cZMDpj3/4Fl2eaNdcvoxxHoH1tYOREsQ22OKDYofGebrNm6CTPUcvLvZm63NL/vzCYdjf9CUhqmA==",
+      "dev": true,
       "dependencies": {
         "history": "^5.2.0",
         "react-router": "6.2.1"
@@ -8624,7 +8638,8 @@
     "node_modules/regenerator-runtime": {
       "version": "0.13.9",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
+      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
+      "dev": true
     },
     "node_modules/regenerator-transform": {
       "version": "0.14.5",
@@ -8720,34 +8735,6 @@
       "dev": true,
       "bin": {
         "jsesc": "bin/jsesc"
-      }
-    },
-    "node_modules/remix-utils": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/remix-utils/-/remix-utils-2.2.0.tgz",
-      "integrity": "sha512-kCsaGsm1s+h86OqROn+twzPcSHwkxQRyCW+wMgv5kRm6j/KlUqdK9U98u+paq676Y9LmcSXUW2clLqBQU5Z2rQ==",
-      "dependencies": {
-        "type-fest": "^2.5.2",
-        "uuid": "^8.3.2"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@remix-run/react": "^1.1.1",
-        "@remix-run/server-runtime": "^1.1.1",
-        "react": "^17.0.2"
-      }
-    },
-    "node_modules/remix-utils/node_modules/type-fest": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.6.0.tgz",
-      "integrity": "sha512-XN1FDGGtaSDA6CFsCW5iolTQqFsnJ+ZF6JqSz0SqXoh4F8GY0xqUv5RYnTilpmL+sOH8OH4FX8tf9YyAPM2LDA==",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/remove-trailing-separator": {
@@ -9133,6 +9120,7 @@
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
       "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+      "dev": true,
       "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
@@ -9163,7 +9151,8 @@
     "node_modules/set-cookie-parser": {
       "version": "2.4.8",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.4.8.tgz",
-      "integrity": "sha512-edRH8mBKEWNVIVMKejNnuJxleqYE/ZSdcT8/Nem9/mmosx12pctd80s2Oy00KNZzrogMZS5mauK2/ymL1bvlvg=="
+      "integrity": "sha512-edRH8mBKEWNVIVMKejNnuJxleqYE/ZSdcT8/Nem9/mmosx12pctd80s2Oy00KNZzrogMZS5mauK2/ymL1bvlvg==",
+      "dev": true
     },
     "node_modules/set-value": {
       "version": "2.0.1",
@@ -11870,6 +11859,7 @@
       "version": "7.14.8",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.8.tgz",
       "integrity": "sha512-twj3L8Og5SaCRCErB4x4ajbvBIVV77CGeFglHpeg5WC5FF8TZzBWXtTJ4MqaD9QszLYTtr+IsaAL2rEUevb+eg==",
+      "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -12360,6 +12350,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@remix-run/react/-/react-1.1.1.tgz",
       "integrity": "sha512-vz7my0sqjuL3BpgvSb+pUFjebof54okDLm2wHI09NnlbPS1ILrrp61zeNmDyrA11tFcxS/JrgKS/q1Frk030mg==",
+      "dev": true,
       "requires": {
         "react-router-dom": "^6.2.1"
       }
@@ -12368,6 +12359,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-1.1.1.tgz",
       "integrity": "sha512-uTTGSjCn2WTXUShruvTuErpbdbGoLu2dZ/zQ0ZHA0MMgP4VDA8xyuBeRcv/By3xqGcu2zSxcEGv7tRPgzU1AtA==",
+      "dev": true,
       "requires": {
         "@types/cookie": "^0.4.0",
         "cookie": "^0.4.1",
@@ -12380,7 +12372,8 @@
         "source-map": {
           "version": "0.7.3",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
+          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+          "dev": true
         }
       }
     },
@@ -12483,7 +12476,8 @@
     "@types/cookie": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
-      "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q=="
+      "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==",
+      "dev": true
     },
     "@types/graceful-fs": {
       "version": "4.1.5",
@@ -13474,7 +13468,8 @@
     "cookie": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
-      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
+      "dev": true
     },
     "cookie-signature": {
       "version": "1.1.0",
@@ -14992,6 +14987,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/history/-/history-5.2.0.tgz",
       "integrity": "sha512-uPSF6lAJb3nSePJ43hN3eKj1dTWpN9gMod0ZssbFTIsen+WehTmEadgL+kg78xLJFdRfrrC//SavDzmRVdE+Ig==",
+      "dev": true,
       "requires": {
         "@babel/runtime": "^7.7.6"
       }
@@ -16205,7 +16201,8 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
     },
     "js-yaml": {
       "version": "3.14.1",
@@ -16263,7 +16260,8 @@
     "jsesc": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
-      "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g=="
+      "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
+      "dev": true
     },
     "json-parse-better-errors": {
       "version": "1.0.2",
@@ -16388,6 +16386,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
@@ -16667,7 +16666,8 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
     },
     "object-copy": {
       "version": "0.1.0",
@@ -17055,6 +17055,7 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
       "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -17064,6 +17065,7 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
       "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
+      "dev": true,
       "peer": true,
       "requires": {
         "loose-envify": "^1.1.0",
@@ -17075,6 +17077,7 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.2.1.tgz",
       "integrity": "sha512-2fG0udBtxou9lXtK97eJeET2ki5//UWfQSl1rlJ7quwe6jrktK9FCCc8dQb5QY6jAv3jua8bBQRhhDOM/kVRsg==",
+      "dev": true,
       "requires": {
         "history": "^5.2.0"
       }
@@ -17083,6 +17086,7 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.2.1.tgz",
       "integrity": "sha512-I6Zax+/TH/cZMDpj3/4Fl2eaNdcvoxxHoH1tYOREsQ22OKDYofGebrNm6CTPUcvLvZm63NL/vzCYdjf9CUhqmA==",
+      "dev": true,
       "requires": {
         "history": "^5.2.0",
         "react-router": "6.2.1"
@@ -17127,7 +17131,8 @@
     "regenerator-runtime": {
       "version": "0.13.9",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
+      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
+      "dev": true
     },
     "regenerator-transform": {
       "version": "0.14.5",
@@ -17205,22 +17210,6 @@
           "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
           "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
           "dev": true
-        }
-      }
-    },
-    "remix-utils": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/remix-utils/-/remix-utils-2.2.0.tgz",
-      "integrity": "sha512-kCsaGsm1s+h86OqROn+twzPcSHwkxQRyCW+wMgv5kRm6j/KlUqdK9U98u+paq676Y9LmcSXUW2clLqBQU5Z2rQ==",
-      "requires": {
-        "type-fest": "^2.5.2",
-        "uuid": "^8.3.2"
-      },
-      "dependencies": {
-        "type-fest": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.6.0.tgz",
-          "integrity": "sha512-XN1FDGGtaSDA6CFsCW5iolTQqFsnJ+ZF6JqSz0SqXoh4F8GY0xqUv5RYnTilpmL+sOH8OH4FX8tf9YyAPM2LDA=="
         }
       }
     },
@@ -17522,6 +17511,7 @@
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
       "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+      "dev": true,
       "peer": true,
       "requires": {
         "loose-envify": "^1.1.0",
@@ -17546,7 +17536,8 @@
     "set-cookie-parser": {
       "version": "2.4.8",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.4.8.tgz",
-      "integrity": "sha512-edRH8mBKEWNVIVMKejNnuJxleqYE/ZSdcT8/Nem9/mmosx12pctd80s2Oy00KNZzrogMZS5mauK2/ymL1bvlvg=="
+      "integrity": "sha512-edRH8mBKEWNVIVMKejNnuJxleqYE/ZSdcT8/Nem9/mmosx12pctd80s2Oy00KNZzrogMZS5mauK2/ymL1bvlvg==",
+      "dev": true
     },
     "set-value": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "typescript": "^4.3.5"
   },
   "dependencies": {
-    "remix-utils": "^2.2.0",
     "uuid": "^8.3.2"
   }
 }

--- a/src/authorizer.ts
+++ b/src/authorizer.ts
@@ -1,5 +1,4 @@
-import { LoaderFunction, redirect } from "@remix-run/server-runtime";
-import { forbidden, unauthorized } from "remix-utils";
+import { LoaderFunction, redirect, json } from "@remix-run/server-runtime";
 import { Authenticator } from "./authenticator";
 
 type LoaderArgs = Parameters<LoaderFunction>[0];
@@ -75,7 +74,7 @@ export class Authorizer<User = unknown, Data = unknown> {
 
     if (!user) {
       if (raise === "response") {
-        throw unauthorized({ message: "Not authenticated." });
+        throw json({ message: "Not authenticated." }, { status: 401 });
       }
       if (raise === "redirect") {
         // @ts-expect-error failureRedirect is a string if raise is redirect
@@ -89,8 +88,8 @@ export class Authorizer<User = unknown, Data = unknown> {
       // @ts-expect-error failureRedirect is a string if raise is redirect
       if (raise === "redirect") throw redirect(failureRedirect);
       if (raise === "response") {
-        if (!rule.name) throw forbidden({ message: "Forbidden" });
-        throw forbidden({ message: `Forbidden by policy ${rule.name}` });
+        if (!rule.name) throw json({ message: "Forbidden" }, { status: 403 });
+        throw json({ message: `Forbidden by policy ${rule.name}` }, { status: 403 });
       }
       if (!rule.name) throw new Error("Forbidden.");
       throw new Error(`Forbidden by policy ${rule.name}`);

--- a/test/authorizers.test.ts
+++ b/test/authorizers.test.ts
@@ -1,8 +1,8 @@
 import {
   createCookieSessionStorage,
   redirect,
+  json,
 } from "@remix-run/server-runtime";
-import { forbidden, unauthorized } from "remix-utils";
 import { Authenticator, Authorizer } from "../src";
 
 describe(Authorizer, () => {
@@ -56,7 +56,7 @@ describe(Authorizer, () => {
 
     await expect(
       authorizer.authorize({ request, params: { id: "1" }, context: {} })
-    ).rejects.toEqual(unauthorized({ message: "Not authenticated." }));
+    ).rejects.toEqual(json({ message: "Not authenticated." }, { status: 401 }));
   });
 
   test("if user is not logged in an failureRedirect is defined redirect", async () => {
@@ -92,7 +92,7 @@ describe(Authorizer, () => {
 
     await expect(
       authorizer.authorize({ request, params: { id: "1" }, context: {} })
-    ).rejects.toEqual(forbidden({ message: "Forbidden by policy isNotAdmin" }));
+    ).rejects.toEqual(json({ message: "Forbidden by policy isNotAdmin" }, { status: 403 }));
   });
 
   test("if user doesn't pass rule throw a Forbidden response without the policy name if it's an arrow function", async () => {
@@ -109,7 +109,7 @@ describe(Authorizer, () => {
 
     await expect(
       authorizer.authorize({ request, params: { id: "1" }, context: {} })
-    ).rejects.toEqual(forbidden({ message: "Forbidden" }));
+    ).rejects.toEqual(json({ message: "Forbidden" }, { status: 403 }));
   });
 
   test("if user doesn't pass rule and failureRedirect is defined throw a redirect", async () => {

--- a/test/strategies/custom.test.ts
+++ b/test/strategies/custom.test.ts
@@ -1,4 +1,4 @@
-import { createCookieSessionStorage } from "@remix-run/node";
+import { createCookieSessionStorage } from "@remix-run/server-runtime";
 import { CustomStrategy } from "../../src/strategies";
 
 describe(CustomStrategy, () => {


### PR DESCRIPTION
I ran into a problem where remix-auth depends on an old version of remix-utils, and this version of remix-utils in turn does not support React 18. My initial plan was simply to upgrade to the latest version of remix-utils, but I realized that remix-auth only uses remix-utils for these response functions. While they certainly look nicer, it feels a bit unnecessary to pull in an entire dependency just for that, so I figured it'd be better to just remove the dependency on remix-utils.

This will make it easier to keep remix-auth up to date in the future.