### PR TITLE
Pass custom error data

### DIFF
--- a/src/error.ts
+++ b/src/error.ts
@@ -1,1 +1,10 @@
-export class AuthorizationError extends Error {}
+export type AuthorizationErrorErrors = string[];
+
+export class AuthorizationError extends Error {
+  constructor(message: string, errors?: AuthorizationErrorErrors) {
+    super(message);
+    this.errors = errors;
+  }
+
+  errors: AuthorizationErrorErrors | undefined;
+}

--- a/src/strategy.ts
+++ b/src/strategy.ts
@@ -4,7 +4,7 @@ import {
   redirect,
   SessionStorage,
 } from "@remix-run/server-runtime";
-import { AuthorizationError } from "./error";
+import { AuthorizationError, AuthorizationErrorErrors } from "./error";
 
 /**
  * Extra information from the Authenticator to the strategy
@@ -112,11 +112,12 @@ export abstract class Strategy<User, VerifyOptions> {
     message: string,
     request: Request,
     sessionStorage: SessionStorage,
-    options: AuthenticateOptions
+    options: AuthenticateOptions,
+    errors?: AuthorizationErrorErrors
   ): Promise<never> {
     // if a failureRedirect is not set, we throw a 401 Response or an error
     if (!options.failureRedirect) {
-      if (options.throwOnError) throw new AuthorizationError(message);
+      if (options.throwOnError) throw new AuthorizationError(message, errors);
       throw json<{ message: string }>({ message }, 401);
     }
 

--- a/src/strategy.ts
+++ b/src/strategy.ts
@@ -118,7 +118,10 @@ export abstract class Strategy<User, VerifyOptions> {
     // if a failureRedirect is not set, we throw a 401 Response or an error
     if (!options.failureRedirect) {
       if (options.throwOnError) throw new AuthorizationError(message, errors);
-      throw json<{ message: string }>({ message }, 401);
+      throw json<{
+        message: string;
+        errors: AuthorizationErrorErrors | undefined;
+      }>({ message, errors }, 401);
     }
 
     let session = await sessionStorage.getSession(


### PR DESCRIPTION
This is more of an idea than a finalized PR - I'm not sure if this approach is the best one, and supporting it fully would require changes to the other community Strategies.

I have been trying to get custom data passed through when throwing an error inside an authentication call (same as [this discussion](https://github.com/sergiodxa/remix-auth/discussions/157)). 

Usually in these situations, I create a custom error class where I can add data to an error message: 

```js
export class FancyError extends Error {
  constructor(message, data) {
    super(message);
    this.data = data;
  }
}

throw new FancyError('Uh oh', {moreData:'yes'})

try{
  throw
} catch(error) {
console.log(error.message) // Uh oh
console.log(error.data) // {moreData:'yes'}
}
```

The problem is that `remix-auth` and at least `remix-auth-form` pass errors around by calling `new AuthorizationError(error.message)` instead of passing through the original error object. This strips away any custom functionality.

This PR adds a simple `errors[]` list to the `AuthorizationError` class, and allows passing an errors list into `authenticate.failure`.

To actually make use of this, you'd have to `throw new AuthorizationError(message,errors)` inside your authentication call, and update your strategy to pass `error.errors` as the final parameter of `failure`.

Here's `remix-auth-form` with that enabled:

```js
export class FormStrategy extends Strategy {
  name = 'form';

  async authenticate(request, sessionStorage, options) {
    let form = await request.formData();

    let user;
    try {
      user = await this.verify({ form, context: options.context });
    } catch (error) {

      let message = error.message;
      return await this.failure(
        message,
        request,
        sessionStorage,
        options,
        error.errors,
      );
    }

    return this.success(user, request, sessionStorage, options);
  }
}
```

And how I'd use it in the app:

```js
authenticator.use(
  new FormStrategy(async ({ form }) => {
    const api = new Api();

    let email = form.get('email');
    let password = form.get('password');

    try {
      return await api.login(email, password);
    } catch (error) {
      // this assumes my api is sending in error.data.errors - you could set any list of strings as the second argument
      throw new AuthorizationError(error.message, error.data?.errors);
    }
  }),
  'user-pass'
);
```