### PR TITLE
Fix custom strategy name not being set in session

### DIFF
--- a/src/authenticator.ts
+++ b/src/authenticator.ts
@@ -27,14 +27,14 @@ export class Authenticator<User = unknown> {
    */
   private strategies = new Map<string, Strategy<User, never>>();
 
-  public readonly sessionKey: NonNullable<AuthenticateOptions["sessionKey"]>;
+  public readonly sessionKey: NonNullable<AuthenticatorOptions["sessionKey"]>;
   public readonly sessionErrorKey: NonNullable<
-    AuthenticateOptions["sessionErrorKey"]
+    AuthenticatorOptions["sessionErrorKey"]
   >;
   public readonly sessionStrategyKey: NonNullable<
     AuthenticateOptions["sessionStrategyKey"]
   >;
-  private readonly throwOnError: AuthenticateOptions["throwOnError"];
+  private readonly throwOnError: AuthenticatorOptions["throwOnError"];
 
   /**
    * Create a new instance of the Authenticator.
@@ -96,9 +96,6 @@ export class Authenticator<User = unknown> {
   /**
    * Call this to authenticate a request using some strategy. You pass the name
    * of the strategy you want to use and the request to authenticate.
-   * The optional callback allows you to do something with the user object
-   * before returning a new Response. In case it's not provided the strategy
-   * will return a new Response and set the user to the session.
    * @example
    * let action: ActionFunction = async ({ request }) => {
    *   let user = await authenticator.authenticate("some", request);
@@ -212,7 +209,7 @@ export class Authenticator<User = unknown> {
   async logout(
     request: Request | Session,
     options: { redirectTo: string }
-  ): Promise<void> {
+  ): Promise<never> {
     let session = isSession(request)
       ? request
       : await this.sessionStorage.getSession(request.headers.get("Cookie"));

--- a/src/authenticator.ts
+++ b/src/authenticator.ts
@@ -124,6 +124,7 @@ export class Authenticator<User = unknown> {
       {
         throwOnError: this.throwOnError,
         ...options,
+        name: strategy,
         sessionKey: this.sessionKey,
         sessionErrorKey: this.sessionErrorKey,
         sessionStrategyKey: this.sessionStrategyKey,

--- a/src/strategy.ts
+++ b/src/strategy.ts
@@ -25,6 +25,10 @@ export interface AuthenticateOptions {
    */
   sessionStrategyKey: string;
   /**
+   * The name used to register the strategy
+   */
+  name?: string;
+  /**
    * To what URL redirect in case of a successful authentication.
    * If not defined, it will return the user data.
    */
@@ -158,7 +162,7 @@ export abstract class Strategy<User, VerifyOptions> {
     // if we do have a successRedirect, we redirect to it and set the user
     // in the session sessionKey
     session.set(options.sessionKey, user);
-    session.set(options.sessionStrategyKey, this.name);
+    session.set(options.sessionStrategyKey, options.name ?? this.name);
     throw redirect(options.successRedirect, {
       headers: { "Set-Cookie": await sessionStorage.commitSession(session) },
     });

--- a/src/strategy.ts
+++ b/src/strategy.ts
@@ -23,7 +23,7 @@ export interface AuthenticateOptions {
    * The key of the session used to set the strategy used to authenticate the
    * user.
    */
-  sessionStrategyKey?: string;
+  sessionStrategyKey: string;
   /**
    * To what URL redirect in case of a successful authentication.
    * If not defined, it will return the user data.
@@ -102,7 +102,8 @@ export abstract class Strategy<User, VerifyOptions> {
   /**
    * Throw an AuthorizationError or a redirect to the failureRedirect.
    * @param message The error message to set in the session.
-   * @param session The session object to set the error in.
+   * @param request The request to get the cookie out of.
+   * @param sessionStorage The session storage to retrieve the session from.
    * @param options The strategy options.
    * @throws {AuthorizationError} If the throwOnError is set to true.
    * @throws {Response} If the failureRedirect is set or throwOnError is false.
@@ -126,7 +127,7 @@ export abstract class Strategy<User, VerifyOptions> {
 
     // if we do have a failureRedirect, we redirect to it and set the error
     // in the session errorKey
-    session.flash(options.sessionErrorKey || "auth:error", { message });
+    session.flash(options.sessionErrorKey, { message });
     throw redirect(options.failureRedirect, {
       headers: { "Set-Cookie": await sessionStorage.commitSession(session) },
     });
@@ -135,7 +136,8 @@ export abstract class Strategy<User, VerifyOptions> {
   /**
    * Returns the user data or throw a redirect to the successRedirect.
    * @param user The user data to set in the session.
-   * @param session The session object to set the user in.
+   * @param request The request to get the cookie out of.
+   * @param sessionStorage The session storage to retrieve the session from.
    * @param options The strategy options.
    * @returns {Promise<User>} The user data.
    * @throws {Response} If the successRedirect is set, it will redirect to it.
@@ -156,7 +158,7 @@ export abstract class Strategy<User, VerifyOptions> {
     // if we do have a successRedirect, we redirect to it and set the user
     // in the session sessionKey
     session.set(options.sessionKey, user);
-    session.set(options.sessionStrategyKey || "strategy", this.name);
+    session.set(options.sessionStrategyKey, this.name);
     throw redirect(options.successRedirect, {
       headers: { "Set-Cookie": await sessionStorage.commitSession(session) },
     });

--- a/src/strategy.ts
+++ b/src/strategy.ts
@@ -27,7 +27,7 @@ export interface AuthenticateOptions {
   /**
    * The name used to register the strategy
    */
-  name?: string;
+  name: string;
   /**
    * To what URL redirect in case of a successful authentication.
    * If not defined, it will return the user data.


### PR DESCRIPTION
## Strategy Name Bug Fix

If a custom name was provided for a strategy when registering it with the authenticator with `.use` then the original strategy name would still be set in the session, as opposed to the custom name provided.

[I've added `name` to the `AuthenticateOptions`](https://github.com/myleslinder/remix-auth/blob/21bd1204b1f3ec4215d834c7fcbc0b63df140d2a/src/strategy.ts#L30) and [in the `authenticator` provide the registered strategy name to the strategy](https://github.com/myleslinder/remix-auth/blob/21bd1204b1f3ec4215d834c7fcbc0b63df140d2a/src/authenticator.ts#L127) so that is [what gets used in the session](https://github.com/myleslinder/remix-auth/blob/21bd1204b1f3ec4215d834c7fcbc0b63df140d2a/src/strategy.ts#L165).
 
The only implication is if a strategy overrode the `success` method of the base Strategy class but I checked all the strategies listed in the community strategies discussion and most of them extend your `Oauth2Strategy` which doesn't override the `success` method. The only exceptions are your FormStrategy and the SupabaseStrategy which both don't override the `success` method and then the EmailLinkStrategy which doesn't call the method at all. 

I've added an additional test to verify that it's working correctly which is passing, along with all the previous tests. 

## JSDoc & Type Updates
- The JSDoc comments in the authenticator were out of date so I updated them.
- I updated the private properties of Authenticator to use types from the `AuthenticatorOptions` as opposed to using them from `AuthenticateOptions`
- Similar to the update with the `sessionErrorKey` value in my previous PR, I have set the  `sessionStrategyKey` in `AuthenticateOptions` to be required as it is always set. I have also removed the fallback values in the case it was undefined (which it never could be).
- `logout` returns a `Promise<never>`
