### PR TITLE
Improve successRedirect type for authenticate

### DIFF
--- a/src/authenticator.ts
+++ b/src/authenticator.ts
@@ -113,6 +113,16 @@ export class Authenticator<User = unknown> {
     request: Request,
     options: Pick<
       AuthenticateOptions,
+      "failureRedirect" | "throwOnError" | "context"
+    > & {
+      successRedirect: AuthenticateOptions["successRedirect"],
+    } = {}
+  ): never;
+  authenticate(
+    strategy: string,
+    request: Request,
+    options: Pick<
+      AuthenticateOptions,
       "successRedirect" | "failureRedirect" | "throwOnError" | "context"
     > = {}
   ): Promise<User> {


### PR DESCRIPTION
If you provide a success redirect, the authenticate function will never return a user, so I have added an overload to correct the return type if a successRedirect is specified.