### PR TITLE
Accept headers in isAuthenticated

### DIFF
--- a/src/authenticator.ts
+++ b/src/authenticator.ts
@@ -191,27 +191,55 @@ export class Authenticator<User = unknown> {
    */
   async isAuthenticated(
     request: Request | Session,
-    options?: { successRedirect?: never; failureRedirect?: never, headers?: never; }
+    options?: {
+      successRedirect?: never;
+      failureRedirect?: never;
+      headers?: never;
+    }
   ): Promise<User | null>;
   async isAuthenticated(
     request: Request | Session,
-    options: { successRedirect: string; failureRedirect?: never, headers?: HeadersInit }
+    options: {
+      successRedirect: string;
+      failureRedirect?: never;
+      headers?: HeadersInit;
+    }
   ): Promise<null>;
   async isAuthenticated(
     request: Request | Session,
-    options: { successRedirect?: never; failureRedirect: string, headers?: HeadersInit }
+    options: {
+      successRedirect?: never;
+      failureRedirect: string;
+      headers?: HeadersInit;
+    }
   ): Promise<User>;
   async isAuthenticated(
     request: Request | Session,
-    options: { successRedirect: string; failureRedirect: string, headers?: HeadersInit }
+    options: {
+      successRedirect: string;
+      failureRedirect: string;
+      headers?: HeadersInit;
+    }
   ): Promise<null>;
   async isAuthenticated(
     request: Request | Session,
     options:
-      | { successRedirect?: never; failureRedirect?: never, headers?: never; }
-      | { successRedirect: string; failureRedirect?: never, headers?: HeadersInit }
-      | { successRedirect?: never; failureRedirect: string, headers?: HeadersInit }
-      | { successRedirect: string; failureRedirect: string, headers?: HeadersInit } = {}
+      | { successRedirect?: never; failureRedirect?: never; headers?: never }
+      | {
+          successRedirect: string;
+          failureRedirect?: never;
+          headers?: HeadersInit;
+        }
+      | {
+          successRedirect?: never;
+          failureRedirect: string;
+          headers?: HeadersInit;
+        }
+      | {
+          successRedirect: string;
+          failureRedirect: string;
+          headers?: HeadersInit;
+        } = {}
   ): Promise<User | null> {
     let session = isSession(request)
       ? request
@@ -220,12 +248,14 @@ export class Authenticator<User = unknown> {
     let user: User | null = session.get(this.sessionKey) ?? null;
 
     if (user) {
-      if (options.successRedirect) throw redirect(options.successRedirect, { headers: options.headers });
-      else return user;
+      if (options.successRedirect) {
+        throw redirect(options.successRedirect, { headers: options.headers });
+      } else return user;
     }
 
-    if (options.failureRedirect) throw redirect(options.failureRedirect, , { headers: options.headers });
-    else return null;
+    if (options.failureRedirect) {
+      throw redirect(options.failureRedirect, { headers: options.headers });
+    } else return null;
   }
 
   /**

--- a/src/authenticator.ts
+++ b/src/authenticator.ts
@@ -191,27 +191,27 @@ export class Authenticator<User = unknown> {
    */
   async isAuthenticated(
     request: Request | Session,
-    options?: { successRedirect?: never; failureRedirect?: never }
+    options?: { successRedirect?: never; failureRedirect?: never, headers?: never; }
   ): Promise<User | null>;
   async isAuthenticated(
     request: Request | Session,
-    options: { successRedirect: string; failureRedirect?: never }
+    options: { successRedirect: string; failureRedirect?: never, headers?: HeadersInit }
   ): Promise<null>;
   async isAuthenticated(
     request: Request | Session,
-    options: { successRedirect?: never; failureRedirect: string }
+    options: { successRedirect?: never; failureRedirect: string, headers?: HeadersInit }
   ): Promise<User>;
   async isAuthenticated(
     request: Request | Session,
-    options: { successRedirect: string; failureRedirect: string }
+    options: { successRedirect: string; failureRedirect: string, headers?: HeadersInit }
   ): Promise<null>;
   async isAuthenticated(
     request: Request | Session,
     options:
-      | { successRedirect?: never; failureRedirect?: never }
-      | { successRedirect: string; failureRedirect?: never }
-      | { successRedirect?: never; failureRedirect: string }
-      | { successRedirect: string; failureRedirect: string } = {}
+      | { successRedirect?: never; failureRedirect?: never, headers?: never; }
+      | { successRedirect: string; failureRedirect?: never, headers?: HeadersInit }
+      | { successRedirect?: never; failureRedirect: string, headers?: HeadersInit }
+      | { successRedirect: string; failureRedirect: string, headers?: HeadersInit } = {}
   ): Promise<User | null> {
     let session = isSession(request)
       ? request
@@ -220,11 +220,11 @@ export class Authenticator<User = unknown> {
     let user: User | null = session.get(this.sessionKey) ?? null;
 
     if (user) {
-      if (options.successRedirect) throw redirect(options.successRedirect);
+      if (options.successRedirect) throw redirect(options.successRedirect, { headers: options.headers });
       else return user;
     }
 
-    if (options.failureRedirect) throw redirect(options.failureRedirect);
+    if (options.failureRedirect) throw redirect(options.failureRedirect, , { headers: options.headers });
     else return null;
   }
 

--- a/test/authenticator.test.ts
+++ b/test/authenticator.test.ts
@@ -196,6 +196,27 @@ describe(Authenticator, () => {
         })
       ).rejects.toEqual(response);
     });
+
+    test("should accept headers as an option", async () => {
+      let user = { id: "123" };
+      let session = await sessionStorage.getSession();
+      session.set("user", user);
+
+      let request = new Request("/", {
+        headers: { Cookie: await sessionStorage.commitSession(session) },
+      });
+
+      let response = redirect("/dashboard", {
+        headers: { "X-Custom-Header": "true" },
+      });
+
+      expect(
+        new Authenticator(sessionStorage).isAuthenticated(request, {
+          successRedirect: "/dashboard",
+          headers: { "X-Custom-Header": "true" },
+        })
+      ).rejects.toEqual(response);
+    });
   });
 
   describe("authenticate", () => {


### PR DESCRIPTION
Allow to pass a HeadersInit object to `isAuthenticated` if a `successRedirect` and/or `failureRedirect` is set.