### PR TITLE
Improve authenticate overload return type

### DIFF
--- a/src/authenticator.ts
+++ b/src/authenticator.ts
@@ -117,7 +117,7 @@ export class Authenticator<User = unknown> {
     > & {
       successRedirect: AuthenticateOptions["successRedirect"];
     }
-  ): never;
+  ): Promise<never>;
   authenticate(
     strategy: string,
     request: Request,


### PR DESCRIPTION
[`@typescript-eslint/await-thenable`](https://typescript-eslint.io/rules/await-thenable/) doesn't like the new overload signature from #211. When I upgrade remix-auth to v3.5.0, it tells me to remove `await` from this line:

```ts
await authenticator.authenticate("auth0", request, { successRedirect });
```

```
Unexpected `await` of a non-Promise (non-"Thenable") value  @typescript-eslint/await-thenable
```

If `authenticate()` implementations are expected to be async, then they will always return promises, so `Promise<never>` would be the correct return type. Just a minor dev experience fix.