### PR TITLE
Update Github Action Workflows to use Node 18

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: '16'
+          node-version: '18'
           cache: 'npm'
       - name: Install dependencies
         uses: bahmutov/npm-install@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Use Node 14
         uses: actions/setup-node@v1
         with:
-          node-version: 14
+          node-version: 18
 
       - name: Install dependencies
         uses: bahmutov/npm-install@v1
@@ -31,7 +31,7 @@ jobs:
       - name: Use Node 14
         uses: actions/setup-node@v1
         with:
-          node-version: 14
+          node-version: 18
 
       - name: Install dependencies
         uses: bahmutov/npm-install@v1
@@ -49,7 +49,7 @@ jobs:
       - name: Use Node 14
         uses: actions/setup-node@v1
         with:
-          node-version: 14
+          node-version: 18
 
       - name: Install dependencies
         uses: bahmutov/npm-install@v1
@@ -64,10 +64,10 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2
 
-      - name: Use Node 14
+      - name: Use Node 18
         uses: actions/setup-node@v1
         with:
-          node-version: 14
+          node-version: 18
 
       - name: Install dependencies
         uses: bahmutov/npm-install@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,9 @@
 name: CI
 
-on: [push]
+on:
+  push:
+    branches: main
+  pull_request: {}
 
 jobs:
   build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2
 
-      - name: Use Node 14
+      - name: Use Node 18
         uses: actions/setup-node@v1
         with:
           node-version: 18
@@ -28,7 +28,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2
 
-      - name: Use Node 14
+      - name: Use Node 18
         uses: actions/setup-node@v1
         with:
           node-version: 18
@@ -46,7 +46,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2
 
-      - name: Use Node 14
+      - name: Use Node 18
         uses: actions/setup-node@v1
         with:
           node-version: 18

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:
-          node-version: 14
+          node-version: 18
           registry-url: https://registry.npmjs.org/
       - run: npm install
       - run: npm run build


### PR DESCRIPTION
The current CI errors seem to stem from the workflows using version 14 of NodeJS. I downgraded the version on my machine to 14 and received the same errors. I've bumped all the NodeJS versions in all the workflows to a minimum of Node 18 which I believe is also the minimum version required by Remix.