### PR TITLE
Update README.md and Fix Errors handling section example

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ export async function loader({ request }: LoaderArgs) {
   let error = session.get(authenticator.sessionErrorKey);
   return json({ error }, {
     headers:{
-      'Set-Cookie': await commitSession(session) //You must commit the session whenever you read a flash
+      'Set-Cookie': await commitSession(session) // You must commit the session whenever you read a flash
     }
   });
 };

--- a/README.md
+++ b/README.md
@@ -240,7 +240,11 @@ export async function loader({ request }: LoaderArgs) {
   });
   let session = await getSession(request.headers.get("cookie"));
   let error = session.get(authenticator.sessionErrorKey);
-  return json({ error });
+  return json({ error }, {
+    headers:{
+      'Set-Cookie': await commitSession(session) //You must commit the session whenever you read a flash
+    }
+  });
 };
 ```
 


### PR DESCRIPTION
In the Errors Handling section example, when reading errors from the session flash, it's essential to commit the new session as well. Otherwise, the errors will persist in the session