### PR TITLE
Allow chaining with `Authenticator#use`

### DIFF
--- a/src/authenticator.ts
+++ b/src/authenticator.ts
@@ -77,7 +77,7 @@ export class Authenticator<User = unknown> {
    *  .use(new SomeStrategy({}, (user) => Promise.resolve(user)))
    *  .use(new SomeStrategy({}, (user) => Promise.resolve(user)), "another");
    */
-  use(strategy: Strategy<User, never>, name?: string): Authenticator {
+  use(strategy: Strategy<User, never>, name?: string): Authenticator<User> {
     this.strategies.set(name ?? strategy.name, strategy);
     return this;
   }


### PR DESCRIPTION
this change allows for chaining to happen while resolving the proper type.

example:

previously:
```ts
export const authenticator = new Authenticator<SessionData["user"]>(
  sessionStorage,
  {
    sessionKey,
  }
);

authenticator.use(auth0Strategy);
```

now:

```ts
export const authenticator = new Authenticator<SessionData["user"]>(
  sessionStorage,
  {
    sessionKey,
  }
).use(auth0Strategy); // previously doing this would result in a type error due to user resolving to `unknown`
```