### PR TITLE
Fix JSDoc `@default` for throwOnError

### DIFF
--- a/src/strategy.ts
+++ b/src/strategy.ts
@@ -41,7 +41,7 @@ export interface AuthenticateOptions {
   /**
    * Set if the strategy should throw an error instead of a Reponse in case of
    * a failed authentication.
-   * @default true
+   * @default false
    */
   throwOnError?: boolean;
   /**


### PR DESCRIPTION
Jsdoc @default for throwOnError? should be false per 

https://github.com/sergiodxa/remix-auth/blob/5982fca4ef2d014b9f4e1fc116dba5c83e3514af/src/authenticator.ts#L68
