### PR TITLE
Fix typo on JSDoc text

### DIFF
--- a/src/strategy.ts
+++ b/src/strategy.ts
@@ -39,7 +39,7 @@ export interface AuthenticateOptions {
    */
   failureRedirect?: string;
   /**
-   * Set if the strategy should throw an error instead of a Reponse in case of
+   * Set if the strategy should throw an error instead of a Response in case of
    * a failed authentication.
    * @default false
    */


### PR DESCRIPTION
Hi @sergiodxa thanks again for the library, while I'm looking at the library code I found a minor comment typo. This PR should fixed it.