### PR TITLE
Fix docs usage of json instead of data

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ export async function action({ request }: Route.ActionArgs) {
 	} catch (error) {
 		// Return validation errors or authentication errors
 		if (error instanceof Error) {
-			return json({ error: error.message });
+			return data({ error: error.message });
 		}
 
 		// Re-throw any other errors (including redirects)
@@ -199,7 +199,7 @@ export async function loader({ request }: Route.LoaderArgs) {
 	if (user) return redirect("/dashboard");
 
 	// Otherwise return null to render the login page
-	return json(null);
+	return data(null);
 }
 ```
 


### PR DESCRIPTION
Code snippet imports `data` but then uses `json`.

<img width="911" height="453" alt="image" src="https://github.com/user-attachments/assets/0ac8e55b-2e78-4515-aa21-abe72a0b8943" />
